### PR TITLE
Fix typo

### DIFF
--- a/docs/Chords.rst
+++ b/docs/Chords.rst
@@ -49,7 +49,7 @@ to get the output “because”. In :ref:`chord notation<Chord Notation>`,
 we would write that chord input as ``b+c``. Since chord inputs are
 performed simultaneously, meaning that all of the keys needed for an
 input are pressed and released at the same time, chord inputs are not
-order-specific. ``b+c`` is the same as ``C+b``. 
+order-specific. ``b+c`` is the same as ``c+b``. 
 
 Chord Output 
 ~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Lowercased the "C" in the chord "C+b". Because the same chord uses lowercase "c", both before and after this instance. And an uppercase letter might be interpreted as holding down Shift.