### PR TITLE
Update SerialAPI.rst, CMD_VAR_SET_KEYMAP typos

### DIFF
--- a/docs/SerialAPI.rst
+++ b/docs/SerialAPI.rst
@@ -409,18 +409,18 @@ CMD_VAR_SET_KEYMAP
    "INPUT","3","Index","Decimal Number","24","For CC1, 0-89 are valid. For CCL, 0-66 are"
    "INPUT","4","Action Id","Decimal Number","112","Valid action Ids range from 8 thru 2047."
    "OUTPUT","0","Command","Chars","VAR",""
-   "OUTPUT","1","SubCommand","Hexadecimal VAR Code","B3",""
+   "OUTPUT","1","SubCommand","Hexadecimal VAR Code","B4",""
    "OUTPUT","2","Keymap","Hexadecimal Keymap Code","A0",""
    "OUTPUT","3","Index","Decimal Number","24",""
    "OUTPUT","4","Action Id","Decimal Number","112","Valid action Ids range from 8 thru 2047. Returns a 00 if either the Keymap Code or Index or Action Id are out of range."
-   "OUTPUT","5","Success","Boolean Number","1","This will be 0 on success, or greater than zero for an error if the chordmap did not exist or the deletion was unsuccessful"
+   "OUTPUT","5","Success","Boolean Number","0","This will be 0 on success, or greater than zero for an error if the chordmap did not exist or the deletion was unsuccessful"
 
 Example(s):
 
 .. code-block:: none
 
-   > VAR B2 A0 24 112
-   VAR B2 A0 24 112 0
+   > VAR B4 A0 24 112
+   VAR B4 A0 24 112 0
 
 RST
 ~~~


### PR DESCRIPTION
### Setup

In the section https://docs.charachorder.com/SerialAPI.html#cmd-var-set-keymap

On table row: INPUT 1
the "Example" column says: B4  
and the "Notes" column says: Set keymap parameter value

That matches the description in section
https://docs.charachorder.com/SerialAPI.html#var-subcommands
```
VAR SubCommand,     Code,   Description
CMD_VAR_SET_KEYMAP, B4,     Sets the value of a key in a keymap.
```

### Typo 1/3

On the CMD_VAR_SET_KEYMAP tables row: OUTPUT 1  
the "Example" column says: B3

B3 does not match the INPUT (B4) or the description in section https://docs.charachorder.com/SerialAPI.html#var-subcommands
```
VAR SubCommand,     Code,   Description
CMD_VAR_GET_KEYMAP, B3,     Gets the value of a key in a keymap.
```
This is the set keymap section, not the get keymap section

Expected: B4

### Typo 2/3

On the CMD_VAR_SET_KEYMAP tables last row: OUTPUT 5  
the "Name" column says: Success  
but the "Example" column says: 1  
the "Notes" column says: This will be 0 on success, or greater than zero for an error if the chordmap did not exist or the deletion was unsuccessful

Expected: 0  
this matches the "Name" column: Success  
and the result of the example below the table
```
> VAR B2 A0 24 112
VAR B2 A0 24 112 0
```

### Typo 3/3

The example below the CMD_VAR_SET_KEYMAP table

```
> VAR B2 A0 24 112
VAR B2 A0 24 112 0
```

uses: B2

which the section https://docs.charachorder.com/SerialAPI.html#var-subcommands
describes as:

```
VAR SubCommand,         Code,   Description
CMD_VAR_SET_PARAMETER,  B2,     Sets the value of a parameter.
```

This is the set keymap section, not the set parameter section

Expected: B4