### PR TITLE
Update SerialAPI.rst, GET_KEYMAP and SET_KEYMAP typos

### DIFF
--- a/docs/SerialAPI.rst
+++ b/docs/SerialAPI.rst
@@ -381,11 +381,11 @@ CMD_VAR_GET_KEYMAP
 
    "INPUT","0","Command","Chars","VAR",""
    "INPUT","1","SubCommand","Hexadecimal VAR Code","B3","Get keymap parameter value"
-   "INPUT","2","Keymap","Hexadecimal Keymap Code","A0",""
+   "INPUT","2","Keymap","Hexadecimal Keymap Code","A1",""
    "INPUT","3","Index","Decimal Number","24","For CC1, 0-89 are valid. For CCL, 0-66 are valid."
    "OUTPUT","0","Command","Chars","VAR",""
    "OUTPUT","1","SubCommand","Hexadecimal VAR Code","B3",""
-   "OUTPUT","2","Keymap","Hexadecimal Keymap Code","A0",""
+   "OUTPUT","2","Keymap","Hexadecimal Keymap Code","A1",""
    "OUTPUT","3","Index","Decimal Number","24",""
    "OUTPUT","4","Action Id","Decimal Number","111","Valid action Ids range from 8 thru 2047."
    "OUTPUT","5","Success","Boolean Number","0","This will be 0 on success, or greater than zero for an error if either the Keymap Code or Index are out of range."
@@ -394,8 +394,8 @@ Example(s):
 
 .. code-block:: none
 
-   > VAR B3 A0 24
-   VAR B3 A0 24 111 0
+   > VAR B3 A1 24
+   VAR B3 A1 24 111 0
 
 CMD_VAR_SET_KEYMAP
 ^^^^^^^^^^^^^^^^^^^^^
@@ -405,12 +405,12 @@ CMD_VAR_SET_KEYMAP
    
    "INPUT","0","Command","Chars","VAR",""
    "INPUT","1","SubCommand","Hexadecimal VAR Code","B4","Set keymap parameter value"
-   "INPUT","2","Keymap","Hexadecimal Keymap Code","A0",""
+   "INPUT","2","Keymap","Hexadecimal Keymap Code","A1",""
    "INPUT","3","Index","Decimal Number","24","For CC1, 0-89 are valid. For CCL, 0-66 are"
    "INPUT","4","Action Id","Decimal Number","112","Valid action Ids range from 8 thru 2047."
    "OUTPUT","0","Command","Chars","VAR",""
    "OUTPUT","1","SubCommand","Hexadecimal VAR Code","B3",""
-   "OUTPUT","2","Keymap","Hexadecimal Keymap Code","A0",""
+   "OUTPUT","2","Keymap","Hexadecimal Keymap Code","A1",""
    "OUTPUT","3","Index","Decimal Number","24",""
    "OUTPUT","4","Action Id","Decimal Number","112","Valid action Ids range from 8 thru 2047. Returns a 00 if either the Keymap Code or Index or Action Id are out of range."
    "OUTPUT","5","Success","Boolean Number","1","This will be 0 on success, or greater than zero for an error if the chordmap did not exist or the deletion was unsuccessful"
@@ -419,8 +419,8 @@ Example(s):
 
 .. code-block:: none
 
-   > VAR B2 A0 24 112
-   VAR B2 A0 24 112 0
+   > VAR B2 A1 24 112
+   VAR B2 A1 24 112 0
 
 RST
 ~~~


### PR DESCRIPTION
"A0" is a typo in both of the examples:
- CMD_VAR_GET_KEYMAP https://docs.charachorder.com/SerialAPI.html#cmd-var-get-keymap
```
> VAR B3 A0 24
VAR B3 A0 24 111 0
```
- CMD_VAR_SET_KEYMAP https://docs.charachorder.com/SerialAPI.html#cmd-var-set-keymap
```
> VAR B2 A0 24 112
VAR B2 A0 24 112 0
```
A0 is only mentioned in the get keymap and set keymap, tables and examples.

The section: Keymap codes https://docs.charachorder.com/SerialAPI.html#keymap-codes
only lists these Keymap codes:

> Primary A1
The default primary keymap. In the CharaChorder One this is called the Alpha keymap, while on the CharaChorder Lite this defaults to a Qwerty layout.

> Secondary A2
The default secondary keymap. In the CharaChorder One this is called the Num-shift keymap, while on the CharaChorder Lite this provides some additional function and numpad keys.

> Tertiary A3
The default tertiary keymap. In the CharaChorder One this is called the Function keymap, while on the CharaChorder Lite this is a copy of the secondary keymap.

The current examples fail (they return a value greater than 0):
(24 is switch location left middle south, by default it types: lowercase o)
- CMD_VAR_GET_KEYMAP
VAR B3 A0 24
VAR B3 A0 24 0 2
- CMD_VAR_SET_KEYMAP
VAR B4 A0 24 112
VAR B4 A0 24 112 2

Both examples work when A0 is changed to A1:
- CMD_VAR_GET_KEYMAP
VAR B3 A1 24
VAR B3 A1 24 111 0

> 111	0x006F	ASCII	o	Lowercase o
- CMD_VAR_SET_KEYMAP
VAR B4 A1 24 112
VAR B4 A1 24 112 0

> 112	0x0070	ASCII	p	Lowercase p

now left middle south types: p