### PR TITLE
fix warnings

### DIFF
--- a/docs/CharaChorder Engine.rst
+++ b/docs/CharaChorder Engine.rst
@@ -1,5 +1,5 @@
 CharaChorder Engine (CCE)
-===================
+=========================
 
 Welcome to the Official CharaChorder Engine guide. You can select the links
 below to navigate to the topics that you find most relevant.

--- a/docs/CharaChorder One.rst
+++ b/docs/CharaChorder One.rst
@@ -1,5 +1,5 @@
 CharaChorder One (CC1)
-===================
+======================
 
 Welcome to the Official CharaChorder One guide. You can select the links
 below to navigate to the topics that you find most relevant.
@@ -191,7 +191,7 @@ If you have :ref:`realtime feedback<GenerativeTextMenu:Realtime feedback>` enabl
    IMPORTANT: :ref:`Realtime feedback<GenerativeTextMenu:Realtime feedback>` is enabled by default on new CharaChorder devices.
 
 Getting Started
-*******************
+***************
 
 There are a few steps that you’ll likely want to take if this is your
 first time using your CharaChorder device. In the following section, we

--- a/docs/CharaChorder Two.rst
+++ b/docs/CharaChorder Two.rst
@@ -1,5 +1,5 @@
 CharaChorder Two (CC2)
-===================
+======================
 
 Welcome to the Official CharaChorder Two (CC2) guide. You can select the links
 below to navigate to the topics that you find most relevant.
@@ -171,7 +171,7 @@ If you have :ref:`realtime feedback<GenerativeTextMenu:Realtime feedback>` enabl
    IMPORTANT: :ref:`Realtime feedback<GenerativeTextMenu:Realtime feedback>` is enabled by default on new CharaChorder devices.
 
 Getting Started
-*******************
+***************
 
 There are a few steps that you’ll likely want to take if this is your
 first time using your CharaChorder device. In the following section, we

--- a/docs/CharaChorder X.rst
+++ b/docs/CharaChorder X.rst
@@ -1,5 +1,5 @@
 CharaChorder X (CCX)
-=======================================
+====================
 
 Welcome to the Official CharaChorder X guide.
 
@@ -58,7 +58,7 @@ The CharaChorder X is a single piece comprised of a circuit board which is enclo
 
 
 Connections
-------------
+-----------
 
 Your new CharaChorder X comes with two connections: a female USB-A port, and a male USB-A connector. The CharaChorder X draws power from your computer via the USB-A male connector and passes on power as well as communicates with your keyboard through the female USB-A port.
 
@@ -184,7 +184,7 @@ decrease these, you can use the up and down arrow keys on your keyboard.
 You can read an explanation on all of the settings on your CharaChorder device :doc:`here<GenerativeTextMenu>`.
 
 The Layout
--------------
+----------
 
 The CharaChorder X uses your keyboard's layout, so you don't have to learn a new one. The CharaChorder X reads the keycodes that your keyboard sends and makes use of them to produce outputs on your computer. The only drawback to this is that the CharaChorder X is unable to read keypresses that do not send a code. One common key that doesn't send a code is the Fn key. This key serves as a layer-access key, locally on your keyboard, that allows you to reach the F-keys. Although the CharaChorder X is unable to read the Fn keypress, the F-keys (F1-F24) will send out a keycode, and, thus, the CharaChorder X will send out that signal to the computer. 
 

--- a/docs/CharaChorder_Lite.rst
+++ b/docs/CharaChorder_Lite.rst
@@ -1,5 +1,5 @@
 CharaChorder Lite (CCL)
-=================
+=======================
 
 Welcome to the Official CharaChorder Lite Guide. You can select the links
 below to navigate to the topics that you find most relevant.

--- a/docs/Chords.rst
+++ b/docs/Chords.rst
@@ -1,5 +1,5 @@
 Chords
-=============================
+======
 One of CharaChorder devices’ greatest features is their
 :doc:`chording<Chords>` ability. Read this section to learn what
 chording is and how you can benefit from it on your own CharaChorder. 
@@ -8,7 +8,7 @@ chording is and how you can benefit from it on your own CharaChorder.
    :local:
 
 What are Chords?
------------------
+----------------
 
 A chord is a type of input/output action on a keyboard: you press two or
 more keys at the same time and release them at the same time, after
@@ -19,7 +19,7 @@ letter at a time. It’s even possible to have chords for phrases and
 entire sentences. 
 
 How do I use Chords?
-----------------------
+--------------------
 
 A chord has an **input** and an **output**. We will describe what each
 of those is and how they affect chords on your CharaChorder device
@@ -29,7 +29,7 @@ talking about carrying out a chord.
 .. _Chord Input:
 
 Chord Input
-~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~
 
 A chord input is the
 combination of keys used in order to get a desired, predetermined
@@ -42,7 +42,7 @@ input are pressed and released at the same time, chord inputs are not
 order-specific. ``b+c`` is the same as ``c+b``. 
 
 Chord Output 
-~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~
 
 A chord
 output is the predetermined letters, words, phrases and/or actions that
@@ -53,7 +53,7 @@ the word “because”, then the word “because” would be the output. In
 input and the output) as ``b+c = because``. 
 
 Chord Notation 
-~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~
 
 Chord
 notation is the way that we write chords for CharaChorder devices. It is
@@ -86,7 +86,7 @@ You can try these chords on your CharaChorder device!
 * ``p+m+i = important``
 
 How do I make Chords? 
-------------------------
+---------------------
 
 You can make chords for your
 CharaChorder using a few different methods which we will discuss below.
@@ -117,12 +117,12 @@ our CharaChorder devices. You can
 Read how below. 
 
 Adding New Chords on Device Manager
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The steps to do this are :ref:`in the Device Manager documentation<Device Manager:Creating a Chord>`.
 
 Impulse chording
-~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~
 
 Impulse chording is a method of adding chords that doesn’t require
 anything except your CharaChorder after a space to type in. It allows
@@ -142,7 +142,7 @@ as part of the output. If you make a mistake when defining the chord
 output, trigger escape and start over instead of deleting the input.
 
 Creating an Impulse Chord on the CharaChorder One
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Standard process for creating an impulse chord on a CharaChorder One: In
 short: 1. CHORD INPUT, 2. CALL IMPULSE, 3. TYPE OUTPUT, 4. CONFIRM
@@ -171,7 +171,7 @@ OUTPUT 5. CONFIRM INPUT
 These steps should take 1-3 seconds. 
 
 Creating an Impulse Chord on the CharaChorder Lite
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Standard process for creating an impulse chord on a CharaChorder Lite:
 In short: 1. CHORD INPUT, 2. CALL IMPULSE, 3. TYPE OUTPUT, 4. CONFIRM
@@ -200,7 +200,7 @@ OUTPUT, 5. CONFIRM INPUT
 These steps should take 1-3 seconds. 
 
 Creating an Impulse Chord on the CharaChorder X
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Standard process for creating an impulse chord on a CharaChorder X: In
 short: 1. CHORD INPUT, 2. CALL IMPULSE, 3. TYPE OUTPUT, 4. CONFIRM

--- a/docs/Device Manager.rst
+++ b/docs/Device Manager.rst
@@ -1,5 +1,5 @@
 Device Manager
-======================================
+==============
 
 The CharaChorder Device Manager is the one-stop-shop for users with a CCOS-powered device. It boasts high quality graphics, animations and a simple user interface. On the device manager, you can change your device's :ref:`layout<Device Manager:Layout>`, manage your :ref:`chord library<Device Manager:Library>`, and adjust your :ref:`settings<Device Manager:Device>`.
 
@@ -12,7 +12,7 @@ Feel free to use the links below to skip to whatever section you would like to r
 
 
 Connecting to the Device Manager
-*********************************
+********************************
 
 You can follow the steps below to connect to the device manager for the first time. 
 
@@ -32,7 +32,7 @@ If these steps were performed correctly, you can see the connected device name i
 .. _serialportaccess:
 
 Linux Serial Port Access
---------------------------
+------------------------
 
 .. warning::
     For **Linux** based users: serial port access is often restricted to specific user groups for security. 
@@ -72,7 +72,7 @@ Replace ``<group_name>`` with the name of the group displayed in the previous st
 Log out and log back in to apply the changes. Your user will now have the necessary permissions to access the serial port.
 
 Device Manager Website
-************************
+**********************
 
 The device manager comes with a navigation menu on the left hand side of the screen. 
 Otherwise, regardless of what page you are on, there are a few helpful buttons you should know about.
@@ -83,7 +83,7 @@ Connect / Device name
 The bottom center of the screen is where you connect to your device and see which you are connected to, as well as other info such as the site version and your device's CCOS version.
 
 Undo and Redo
----------------
+-------------
 
 .. image:: /assets/images/ManagerUndoRedo.png
   :width: 200
@@ -92,7 +92,7 @@ Undo and Redo
 Near the top left corner, the device manager has handy undo and redo buttons which do exactly what their names describe. If you're making changes to your layout, your chords, or your layout, you can step back, one change at a time, all the way back to the very first change that you made during that session. Once you're stepped back, you can step forward to redo the change(s) that was/were undone. 
 
 Color Scheme
---------------
+------------
 On the bottom right of the device manager, you'll see a circle with a solid color. Hovering over this circle will reveal the label "color scheme." You can click this circle to change the color scheme of the device manager. In the color scheme menu, you can choose your preferred color using a color pallette, an RGB color system, or by clicking the dropper icon to choose a color on your screen.
 
 .. image:: /assets/images/ManagerColorScheme.png
@@ -100,11 +100,11 @@ On the bottom right of the device manager, you'll see a circle with a solid colo
   :alt: The Color Scheme Menu
 
 Light and Dark Mode
---------------------
+-------------------
 Also in the bottom right-hand corner, you'll find a sun or moon icon where you can toggle between light and dark mode. This toggle can help those who would rather a brighter screen to see better or a darker screen to reduce eye strain.
 
 Save Button
--------------
+-----------
 
 .. image:: /assets/images/ManagerSaveButton.png
   :width: 200
@@ -117,12 +117,12 @@ If you make changes in the :ref:`library<Device Manager:Library>`, the :ref:`lay
 
 
 Device
-***************
+******
 The Device Tab is the place where you can configure most settings of your :ref:`connected<Device Manager:Connecting to the Device Manager>` CCOS device and create backups.
 Read on to see the different settings you can change. You can find more detailed explanations in the :doc:`GTM<GenerativeTextMenu>` section.
 
 Backup Section
-----------------
+--------------
 
 .. image:: /assets/images/ManagerHistoryMenu.png
   :width: 400
@@ -135,7 +135,7 @@ If you toggle the "Auto-backup" on, then the website will store a copy of your b
 On the Device Manager, you can create backups of your chords, your layout, and even your settings. Follow the steps below to create a backup and to restore saved backups to your :doc:`CCOS<CCOS>` device.
 
 Creating a Backup
-~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~
 .. Note::
 	In order to follow these steps, you must already have your device :ref:`connected<Device Manager:Connecting to the Device Manager>` to the device manager.
 
@@ -151,7 +151,7 @@ Creating a Backup
 Congratulations! Now you have created a backup.
 
 Restoring from a Backup
-~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~
 Additionally, you can restore your chords, your layout, and your settings on the Device Manager. Follow the steps below to do so.
 
 .. Note::
@@ -174,7 +174,7 @@ Additionally, you can restore your chords, your layout, and your settings on the
 5. Once you see the changes that the restore file made, you can click :ref:`save<Device Manager:Save Button>` to apply the changes.
 
 Device Section
-----------------
+--------------
 
 .. _Autoreconnect:
 
@@ -193,7 +193,7 @@ Additionally, you can reset some parts of your device files such as your chords,
   :alt: The Device settings box
 
 Spurring
-----------
+--------
 
 .. dropdown:: What is Spurring?
 
@@ -208,7 +208,7 @@ Spurring
 In this box, you can enable or disable spurring mode as well as increase or decrease the :ref:`spurring timeout setting<GenerativeTextMenu:Spurring Timeout>`.
 
 Arpeggiates
--------------
+-----------
 .. dropdown:: What are arpeggiates?
 
 	Arpeggiate actions are timed actions that can modify a :ref:`chord<Chords:What are Chords?>` after the chord is performed. A quick example of this is the use of :ref:`chord modifiers<Device Manager:Chord Modifiers>` after you perform the chord. You can read that section for information on how the chord modifiers work.
@@ -222,7 +222,7 @@ Arpeggiates
 In this box, ou can enable or disable arpeggiates as well as increase or decrease the :ref:`arpeggiate timeout setting<GenerativeTextMenu:Arpeggiate Timeout>`.
 
 Chord Modifiers
------------------
+---------------
 .. dropdown:: What are chord modifiers?
 
 	Chord modifiers are actions that change a chord when :ref:`chorded<Chords:What are Chords?>` at the same time as the :ref:`chord input<Chords:Chord Input>`, or when pressed immediately after (arpeggiately) the :ref:`chord<Chords:What are Chords?>`, provided that :ref:`arpeggiates<GenerativeTextMenu:Arpeggiate>` are enabled.
@@ -239,7 +239,7 @@ Chord Modifiers
 In this box, you can read a brief explanation of chord modifiers and how to access them.
 
 Capitalization
-~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~
 The capitalization modifier modifies any chord so that the first letter is capitalized on :ref:`output<Chords:Chord Output>`. This :ref:`modifier<Device Manager:Chord Modifiers>` can be performed together with a :ref:`chord<Chords:What are Chords?>` or :ref:`arpeggiately<GenerativeTextMenu:Arpeggiate>`.
 
 The capitalization modifier is located on the ``SHIFT`` key. In the :ref:`layout editor<Device Manager:Layout>`, this key can be either "Shift Keyboard Modifier (Left)" or "Shift Keyboard Modifier (Right)".
@@ -248,32 +248,32 @@ The capitalization modifier is located on the ``SHIFT`` key. In the :ref:`layout
 	If you have ``CAPS LOCK`` active, all letters in a chord will be capitalized except the first one when using this modifier.
 
 Present Tense
-~~~~~~~~~~~~~~
+~~~~~~~~~~~~~
 The present tense modifier modifies supported chords so that they turn into their present tense variants. The word "run" would be modified into "running" and the word "work" would be turned into "working". This :ref:`modifier<Device Manager:Chord Modifiers>` can be performed together with a :ref:`chord<Chords:What are Chords?>` or :ref:`arpeggiately<GenerativeTextMenu:Arpeggiate>`.
 
 The present tense modifier has different locations depending on your device. On the CharaChorder One, this modifier is linked to the "AMBIDEXTROUS THROWOVER (LEFT)" key. On the CharaChorder Lite, it's linked to the "NUMERIC LAYER (LEFT)" key.
 
 Pluralizer
-~~~~~~~~~~~
+~~~~~~~~~~
 The pluralizer modifier makes supported chords plural. It will add an "s" or "es" to the end of supported chords. "Box" will turn into "boxes" and "dog" will become "dogs". This :ref:`modifier<Device Manager:Chord Modifiers>` can be performed together with a :ref:`chord<Chords:What are Chords?>` or :ref:`arpeggiately<GenerativeTextMenu:Arpeggiate>`.
 
 The pluralizer modifier has different locations depending on your device. On the CharaChorder One, it's linked to the "AMBIDEXTROUS THROWOVER (RIGHT)" key. On the CharaChorder Lite, it's linked to the "RIGHT SPACEBAR" key, not to be confused with the "SPACE" key.
 
 Past Tense
-~~~~~~~~~~~
+~~~~~~~~~~
 The past tense modifier modifies supported chords so that they turn into their past tense variants. The word "run" would be modified into "ran". The word "work" would be turned into "worked". This :ref:`modifier<Device Manager:Chord Modifiers>` can be performed together with a :ref:`chord<Chords:What are Chords?>` or :ref:`arpeggiately<GenerativeTextMenu:Arpeggiate>`.
 
 The past tense modifier has different locations depending on your device. On the CharaChorder One, it's linked to the "NUMERIC LAYER (LEFT)" key. On the CharaChorder Lite, it's linked to the "SPACE" key, not to be confused with the "RIGHT SPACEBAR" key.
 
 Comparative
-~~~~~~~~~~~~~
+~~~~~~~~~~~
 The comparative modifier modifies supported chords so that they turn into their comparative variant. "Big" becomes "bigger" and "small" turns into "smaller". This :ref:`modifier<Device Manager:Chord Modifiers>` can be performed together with a :ref:`chord<Chords:What are Chords?>` or :ref:`arpeggiately<GenerativeTextMenu:Arpeggiate>`.
 
 The comparative modifier is located on the "NUMERIC LAYER (RIGHT)" key on both the CharaChorder One and the CharaChorder Lite.
 
 
 Character Entry
-----------------
+---------------
 .. dropdown:: What is Character Entry?
 
 	Character entry, known to the CharaChorder community as "chentry," refers to typing one character at time. 
@@ -323,7 +323,7 @@ In this box, you can change a few settings that relate to using your device for 
 	If you have a faster computer, then you can lower this setting to make chording and the :doc:`GTM<GenerativeTextMenu>` feel snappier and more responsive.
 
 Mouse
--------
+-----
 .. dropdown:: Mouse???
 
 	:doc:`CCOS<CCOS>` has mouse functionality. This means that your CharaChorder, or CCOS-powered keyboard, has the ability to control your computer's mouse. These settings affect the mouse usage on your CharaChorder.
@@ -357,7 +357,7 @@ In this box, you can adjust settings relating to :doc:`CCOS'<CCOS>` mouse abilit
 	You can read a more in-depth explanation of the polling rate in the :ref:`GTM section<GenerativeTextMenu:Poll Rate>`.
 
 Chording
------------
+--------
 .. dropdown:: What is Chording?
 
 	Chording is the beautiful ability of pressing multiple keys at a time to get a predefined output, whether it's a single word, an entire phrase, or important addresses. 
@@ -393,7 +393,7 @@ In this box, you can adjust settings relating to :doc:`CCOS'<CCOS>` :doc:`chordi
 	This toggle allows you to enable or disable :ref:`compound chords<Chords:Compound Chords>`.
 
 RGB
-------
+---
 The RGB settings ONLY affect the CharaChorder Lite as of February of 2024. 
 
 These settings adjust the color and brightness of your CharaChorder Lite.
@@ -404,7 +404,7 @@ These settings adjust the color and brightness of your CharaChorder Lite.
   :alt: The RGB settings box
 
 Library
-***************
+*******
 .. image:: /assets/images/ChordManager.png
   :width: 1200
   :alt: A picture of the Library
@@ -428,7 +428,7 @@ Under the text box if your device supports it you can find some shortcuts to hel
 Finally, at the bottom of the page, if you hover over the Device name you'll notice that you can hold Shift and click on it to "Sync".  If you do this, it will have the device manager read your device's chord library again. This process can take a few seconds.
 
 Creating a Chord
------------------
+----------------
 You can follow the steps below to create a new chord on the device manager.
 
 .. Note::
@@ -461,7 +461,7 @@ You can follow the steps below to create a new chord on the device manager.
 
 
 Deleting a Chord
------------------
+----------------
 You can follow the steps below to delete a chord in the device manager.
 
 .. Note::
@@ -482,7 +482,7 @@ You can follow the steps below to delete a chord in the device manager.
 
 
 Editing a Chord
------------------
+---------------
 You can follow the steps below to edit an existing chord in the device manager.
 
 .. Note::
@@ -506,19 +506,19 @@ You can follow the steps below to edit an existing chord in the device manager.
 	Once you click :ref:`save<Device Manager:Save Button>`, the chord(s) that you've modified will change color to match the rest of the list and the floating dot will disappear.
 
 Share button
--------------
+------------
 Next to every chord, you will see a share icon. You can share individual chord maps with others by pressing this button. When you do, your computer's clipboard will copy a URL that you can share with anyone who can then add that exact chord map to their own CharaChorder through the Device Manager. 
 
 When you follow a chord map link, you'll be taken to the Library where you'll see the new chord map ready to be :ref:`saved<Device Manager:Save Button>`.
 
 
 Layout
-**************
+******
 The Device Manager has a very intuitive layer editor. It's the third option in the main navigation bar at the left of the page. When you go to this tab, you'll see a diagram of your device, with each key filled in with the corresponding :ref:`action code<Device Manager:Using Action Codes>`.
 
 
 Layer Selector
-----------------
+--------------
 
 .. dropdown:: Explanation of Layers on CCOS Devices
 
@@ -555,11 +555,11 @@ Layer Selector
 Above the diagram of your device, you'll see a circle with the letters "ABC" in the middle. The circle, together with the "wings" on either side (one on the left with the numbers "123" inscribed and one on the right with "fx" stylized within), make up the layer selector. You can select any one of these to view the keys that are mapped to each location, on each layer.
 
 Remapping
-------------
+---------
 On the layer editor, you can remap your layout by using :ref:`action codes<Device Manager:Using Action Codes>`. Follow the instructions below to remap your device one key at a time.
 
 How to Remap Your Keys
-~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~
 
 .. Note::
 	In order to follow these steps, you must already have your device :ref:`connected<Device Manager:Connecting to the Device Manager>` to the device manager.
@@ -583,15 +583,15 @@ How to Remap Your Keys
 	Once you click :ref:`save<Device Manager:Save Button>`, the highlighted key(s) will lose their highlight and the floating dot will disappear. Your layout diagram will be black and white.
 
 Using Action Codes
-~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~
 You can use action codes in chord outputs as well as while :ref:`remapping<Device Manager:Remapping>` keys.
 
 What are Action Codes
-^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^
 Action codes are data that :doc:`CCOS<CCOS>` interprets as characters. **Put simply, they are the characters that we see while typing.** These include letters, numbers, special characters, function keys, and others. 
 
 Action Code Menu
-^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^
 You can open the action codes menu one of two ways:
 
 1. While typing a chord :ref:`chord output<Chords:Chord Output>` in the :ref:`library<Device Manager:Library>`, you’ll notice that your cursor will have a bubble with a + above it. You can click this to open the action codes menu.
@@ -603,7 +603,7 @@ In this menu, you can scroll through :ref:`available action codes<Device Manager
 If you ever need to leave the action codes menu, simply click the X at the top right of the menu. This will close out the box and not make any changes.
 
 Action Code Categories
-..........................
+......................
 There are eight different categories in the action code menu. These are: ASCII Macros, ASCII, CharaChorder One, CharaChorder, CP-1252, Keyboard, Mouse, and Key Codes.
 
 
@@ -633,7 +633,7 @@ There are eight different categories in the action code menu. These are: ASCII M
    ,,,,,,,,,,,,,,,,,,,,,,,,,
 
 Remove Button
-................
+.............
 You can use the "Remove" button on the top right of the action codes menu to remove the currently assigned action code from the selected key in the :ref:`layout editor<Device Manager:Layout>`. 
 
 If you select the "Remove" button while typing a :ref:`chord output<Chords:Chord Output>` in the :ref:`library<Device Manager:Library>`, it will NOT remove any action. Instead, it will add a "blank" action that will be labeled ``0x0``. 
@@ -641,7 +641,7 @@ If you select the "Remove" button while typing a :ref:`chord output<Chords:Chord
 
 
 Available Action Codes
-^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^
 You can see the action codes below, or view them externally `here. <https://docs.google.com/spreadsheets/d/1--T9bXshCIC-OVly-CY3rK87fgb7AHgJl3IySh7cmHc/edit#gid=0>`__
 
 .. raw:: html

--- a/docs/FAQs.rst
+++ b/docs/FAQs.rst
@@ -72,8 +72,8 @@ How do you access a full keyboard with fewer buttons?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The switches on a CharaChorder Two device are 3-dimensional, providing 5 unique inputs per switch.
 
-Dimensions and Weight
-~~~~~~~~~~~~~~~~~~~~~
+Dimensions and Weight CC Two
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 - **Device**: 11 ⅝" x 4 ⅜" x 1 ⅛", 10.7 oz (without USB-C), 12.1 oz (with USB-C)  
 - **Internal box/case with insert**: 12 3/16" x 8 1/16" x 2 ⅜", 15.8 oz  
 - **Final shipping box**: 13" x 9" x 2 ¾", 2.04 lbs  
@@ -83,8 +83,8 @@ Dimensions and Weight
 
 CharaChorder Lite FAQs
 ----------------------
-Dimensions and Weight
-~~~~~~~~~~~~~~~~~~~~~
+Dimensions and Weight CC Lite
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 - **Device**: 11 ⅝" (length) x 4 ⅛" (width) x 1 5/16" (height), 1 lb 0.5 oz  
 - **Case**: 14 3/16" x 6 ⅜" x 2 ⅛", 9 oz  
 - **Final shipping box**: 14 ¼" x 6 ½" x 2 ¾", 2.05 lbs  
@@ -95,6 +95,7 @@ Is there any difference between the Lite and the X?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 - **Lite**: Can handle up to 12-key singular chords.  
 - **X**: Can handle up to 6-key singular chords initially.  
+
 The Lite has special keys absent on standard keyboards, which can be remapped on the X.
 
 Will CCX work on a laptop?
@@ -133,7 +134,7 @@ Is CCX the same as CC Engine but with USB support?
 Yes, the CCX contains the same hardware as the CC Engine, with an additional chip for USB input. The CC Engine requires custom circuit design, while the CCX is a consumer-ready product.
 
 Can the X connect to an external host or network?
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The CCX uses **HID** and **Serial over USB** protocols. It cannot connect directly to a network without external software to route the traffic. The Device Manager is one such software tool compatible with some Chromium based browsers.
 
 Will CCX work with a USB-A to USB-C adapter?

--- a/docs/GenerativeTextMenu.rst
+++ b/docs/GenerativeTextMenu.rst
@@ -1,7 +1,7 @@
 .. _Generative Text Menu (GTM):
 
 Generative Text Menu (GTM)
-=============================
+==========================
 
 ``CharaChorder GTM [ >K<eyboard || >M<ouse || >C<hording || >D<isplay || >R<esources ]``
 

--- a/docs/Layout.rst
+++ b/docs/Layout.rst
@@ -1,19 +1,20 @@
 .. _Layout:
+
 Layout
-=======
+======
 
 Layout quirks
-------
+-------------
 
 TL;DR, so what does this mean for me?
-^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 First of all, here are some pitfalls
 
 * If you set for example `$`, the CCOS types this as "hold shift press 4 release shift". 
   Meaning if you press `$` and `3` together, **you'll actually type "$#" instead of "$3"**
   because the CCOS needs to hold shift for typing the `$` sign
-    - *Avoid putting characters that need shift and normal characters on the same layer*
+  - *Avoid putting characters that need shift and normal characters on the same layer*
 * Using for example a German layout on the OS will swap z and y, just like on a normal keyboard.
 * Using any non-ASCII, non-Chara, non-keyboard characters will *only* work on Windows.
 * The hacks used by Chara can have unexpected consequences in some programs which intercept raw input
@@ -27,7 +28,7 @@ First of all, here are some pitfalls
 The other solution is to use your local layout and mentally remap. So if you wanted to type the cyrillic `Ф`, you set the Russian layout on your OS, and map the key to `a` (which will send the key-code that corresponds to Ф on a Russian layout)
 
 What's even going on?
-^^^^^
+^^^^^^^^^^^^^^^^^^^^^
 
 Intuitively you'd expect keyboards to send the letter that's printed on the key pressed to the system. However, unfortunately that's not the case. There is *no way* for any device to tell the OS which letter should be typed, on any operating system.
 
@@ -38,7 +39,7 @@ The only convention here is *where* the keys are located - *on a standard layout
 There is no standard for other typing input devices,  nor is there a way for the device to know what layout is selected by the OS.
 
 How does CharaChorder deal with this?
-^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If you set a layout on the CCOS, it moves the key-code locations around. 
 
@@ -46,7 +47,7 @@ If you set a layout on the CCOS, it moves the key-code locations around.
   Setting the letter `a` on a switch doesn't actually send "print a" to the computer - it sends a "key where the a would be on the us layout pressed" to the OS**.
 
 So how can I add äöüß etc when it's not on the US layout?
-^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 There is a special feature on Windows that allows you to directly type *any* Unicode character with your keyboard, by holding `alt` and typing a numeric code.
 
@@ -58,7 +59,7 @@ Because this is a Windows feature, this only works on Windows. However even this
 There are similar workarounds for Linux and Mac, but as of now not supported by CCOS.
 
 The "real" solution
-^^^^^^^
+^^^^^^^^^^^^^^^^^^^
 
 The best solution is always to rely on the OS mapping.
 

--- a/docs/Master Forge.rst
+++ b/docs/Master Forge.rst
@@ -1,5 +1,5 @@
 Master Forge
-===================
+============
 
 Welcome to the Official Master Forge guide. You can select the links
 below to navigate to the topics that you find most relevant.
@@ -41,7 +41,7 @@ box. Once you open the box, you’ll find your brand new Master Forge inside its
 Once you open the tactical case, you’ll meet your shiny, new Master Forge. The Master Forge consists of two digitizers with 8, 5-way switches, joined together by a :ref:`mechanical bridge connector<Master Forge:Mechanical Bridge Connector>`.
 
 The Digitizers
-~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~
 
 Your device will come with two Digitizers which, together, comprise the Master Forge. Each digitizer typically corresponds to each hand and is designed for the ergonomics and comfort of each hand. The digitizers are composed of a 3D printed endoskeleton and a machined-aluminum exoskeleton. The exoskeleton of the digitizer is actually two pieces which are the trapezoidal-shaped “shell,” and the flat and partially hollowed out “baseplate”. They are held together by five M2, Philips screws which are
 under the “feet” pads of the device. The feet are round, rubberized and help the device to have a grip on desks and other smooth surfaces.
@@ -70,7 +70,7 @@ On the sides of each digitizer, you'll notice the :ref:`bookend rails<The Booken
   :alt: Original Backer Case
 
 The Bridge Connector
-~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~
 
 Out of the box, your :ref:`digitizers<The Digitizers>` will be connected by a mechanical bridge :doc:`bolt-on<Bolt-Ons>`. This :doc:`bolt-on<Bolt-Ons>` is also machined-aluminum and made from a slotted rail. It's held in place by two, M3 nylon screws. Nylon screws don't "set" into the aluminum like steel screws, which prevents damage to the slotted rails, since the slotted rails at the front of the device don't have any holes for screws to go into. It's more of a friction hold, which is a key concept of :doc:`bolt-ons<Bolt-Ons>`. 
 
@@ -92,7 +92,7 @@ The electrical bridge connector is a thin printed circuit board that ends in a U
 When connected by the official Forge bridge connector, the left digitizer should be the one connected directly to your computer. See :ref:`Getting Started<tag?>` for more information about this.
 
 The Bookend Rails
-~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~
 
 Each :ref:`digitizer<The Digitizers>` of the Master Forge comes with three removable bookend rails. These rails are what allow the digitizers to attach to other :doc:`anchor bodies<Anchor Bodies>` and :ref:`bolt-ons<Bolt-Ons>`. 
 
@@ -104,7 +104,7 @@ Each :ref:`digitizer<The Digitizers>` of the Master Forge comes with three remov
 The bookend rails are made of machined aluminum and are held in place on the body of the :ref:`digitizers<The Digitizers>` by two (size), steel screws. 
 
 The Splitter
-~~~~~~~~~~~~~~
+~~~~~~~~~~~~
 
 Included with every Master Forge order is a 3D-printed Splitter. This piece serves to prevent anything from falling into the space between the forge :ref:`digitizers<The Digitizers>` whenever these are connected by the :ref:`bridge connector<The Bridge Connector>`.
 
@@ -173,13 +173,14 @@ Another cable that may be included with your order is a 3.2 gen 2, braided USB-C
         2. As pointed out in the :ref:`getting started section<Port Requirement>` of this page, power to an :doc:`anchor body<Anchor Bodies>` or :ref:`bolt-on<Bolt-Ons>` must be received through the front left USB-C port. This means that every anchor body or bolt-on that you add to your system has to be linked to the Master through the port on the front left.   
 
 Getting Started
-*******************
+***************
 
 The Master Forge is plug-and-play, so it doesn’t require any
 additional software to work. Before plugging your Forge in for
 the first time, it’s important to make sure that either the :ref:`electrical bridge connector<Master Forge:The Bridge Connector>` or a USB-C cable is correctly plugged into both :ref:`digitizers<Master Forge:The Digitizers>`. 
 
 .. _Port Requirement:
+
 All Forge :doc:`anchor bodies<Anchor Bodies>`, including the Master Forge Digitizers, should be connected to a power source through their front, left USB-C port. It's important to use that specific port to connect your device to your computer because no other port will permit your Forge to function correctly. As a rule of thumb, all Forge :doc:`anchor bodies<Anchor Bodies>` must receive power through their front, left port. The other three ports are outgoing ports in order to connect other :doc:`anchor bodies<Anchor Bodies>` and :doc:`bolt-ons<Bolt-Ons>`. Each additional :doc:`anchor body<Anchor Bodies>` or :doc:`bolt-on<Bolt-Ons>` will need to "receive" power from the "Master" :doc:`anchor body<Anchor Bodies>`, or from an :doc:`anchor body<Anchor Bodies>` or :doc:`bolt-on<Bolt-Ons>` connected to the Master. A "Master" :doc:`anchor body<Anchor Bodies>` is the one connected directly to your computer. Please note that some :doc:`bolt-ons<Bolt-Ons>` may function as a Master.
 
 If you haven't done so, now would be the time to plug the included USB-C to USB-A cable included with your order into the LEFT :doc:`digitizer<Master Forge:The Digitizers>`. If you would rather use an after-market USB-C to USB-C cable instead, due to a personal preference or computer requirement, that is also okay. Regardless of your selection, we'll refer to the cable that connects directly to the computer as the sole Power Cable. If you have any additional :doc:`bolt-ons<Bolt-Ons>`, now would be a good time to plug them into your Master. 
@@ -234,19 +235,19 @@ training website; https://www.iq-eq.io/#/
   :alt: Practicing on DOT I/O
 
 Setting Up
------------
+----------
 
 There are a few steps that you’ll likely want to take if this is your
 first time using your Master Forge. In the following section, we
 will update your device, explain navigation in the :doc:`GTM<GenerativeTextMenu>`, and demonstrate the default layout on your new device.
 
 Updating your Device
-~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~
 
 .. _M4G-checking-your-devices-firmware:
 
 Checking your Device’s Firmware
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You can check your device’s current firmware by following the steps
 below: 
@@ -254,13 +255,14 @@ below:
 #. On a chromium based browser, such as Chrome, go to the CharaChorder `Device Manager <https://charachorder.io/config/layout/>`__ 
 #. Click “Connect” at the bottom center of the page
    
-.. _Connect Button:
+.. _Connect Button Check Firmware:
 .. image:: /assets/images/FW-connect-button.JPG
   :width: 600
   :alt: Connect Button on Device Manager
+
 3. When the popup box comes up that reads “charachorder.io wants to connect to a serial port,” choose your Master Forge, then click the blue “connect” button
 
-.. _Serial Port Popup:
+.. _Serial Port Popup Check Firmware:
 .. image:: /assets/images/SerialPort-Message.webp
   :width: 600
   :alt: Popup to select serial device
@@ -275,7 +277,7 @@ firmware version in the bottom left of your screen. It will read something like 
   :alt: Checking the firmware on Device Manager
 
 Updating the Firmware
-^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^
 
 If you find that your device is not running the latest firmware version,
 you can follow the steps below to update your device. You can check
@@ -302,13 +304,13 @@ The Master Forge supports over-the-air (OTA) updates. You can follow the steps b
     #. You can compare the latest release (the version at the top of the list) with your device's version. Select your desired version.
     #. If you haven't done so already, Connect your device to the Manager by clicking "Connect" at the bottom of the page
         
-        .. _Connect Button:
+        .. _Connect Button Update Firmware:
         .. image:: /assets/images/FW-connect-button.JPG
           :width: 600
           :alt: Connect Button on Device Manager
     #. When the popup box comes up that reads “charachorder.io wants to connect to a serial port”, choose your Master Forge, then click the blue “connect” button
      
-        .. _Serial Port Popup:
+        .. _Serial Port Popup Update Firmware:
         .. image:: /assets/images/SerialPort-Message.webp
           :width: 600
           :alt: Popup to select serial device
@@ -330,13 +332,13 @@ Your device will reboot on its own and will have the new firmware on it once it 
  		#. On a chromium based browser, such as Chrome, go to the CharaChorder `Device Manager <https://charachorder.io/ccos/>`__ 
  		#. If not auto-connected, click "Connect"
 
-       		   .. _Connect Button:
+       		   .. _Connect Button Emergency:
      		   .. image:: /assets/images/FW-connect-button.jpg
     		      :width: 600
     		      :alt: Connect Button on Device Manager
  		#. When the popup box comes up that reads “manager.charachorder.com wants to connect to a serial port”, choose the CCOS device you wish to update, then click the blue “connect” button
 
-        		 .. _Serial Port Popup:
+        		 .. _Serial Port Popup Emergency:
       		  .. image:: /assets/images/SerialPort-Message.jpg
        		   :width: 600
         		  :alt: Popup to select serial device
@@ -403,12 +405,13 @@ Your device will reboot on its own and will have the new firmware on it once it 
 		 #. When your computer asks you how you would like to resolve the issue of two files with the same name, select “Replace file”.
 
 		Once again, your Forge will automatically reboot and the
+
 Forge drive will have disappeared. You can check your device’s firmware
 version by following the steps :ref:`here<m4g-checking-your-devices-firmware>`.
 
 
 Understanding the Settings
-----------------------------
+--------------------------
 
 The Forge has operational settings that are user-configurable. Since the
 device is plug-and-play, you don’t need any software to edit the
@@ -441,7 +444,7 @@ decrease these, you can use the arrow keys on your :ref:`digitizers<The Digitize
 You can read an explanation on all of the settings on your CharaChorder device :doc:`here<GenerativeTextMenu>`.
 
 Learning the Layout
----------------------
+-------------------
 
 The default on the Master Forge :ref:`digitizers<The Digitizers>`, which we will refer to as the M4 English layout, has been designed to favor :doc:`bigrams<Logic behind the Layout>` and :doc:`trigrams<Logic behind the Layout>` commonly used in the English language while making the letters accessible for a logical choice of :doc:`lexical<Chords>`. You can find the map below.
 
@@ -570,7 +573,7 @@ Shift Modifier
            :widths: auto
 
            "Alpha key", "Shifted key"
-           "`", "~" 
+           "\`", "~" 
            "1", "\!"
            "2", "\@"
            "3", "\#"
@@ -633,12 +636,12 @@ suit their personal needs. For a thorough explanation on how remapping
 works and how to remap your device, visit the :ref:`remapping section<Device Manager:Remapping>`
 
 Master Forge Configurations
-****************************
+***************************
 
 When the Master Forge was `unveiled <https://youtu.be/fux9gU3M25E?si=u4KW7OaUUUNINfKD&t=1025>`__ in Novemeber of 2023, CharaChorder began taking pre-orders offering everyone the same bundle. In September of 2024, CharaChorder ran a `Kickstarter <https://www.kickstarter.com/projects/charachorder/the-master-forge-a-keyboard-built-for-you>`__ campaign for the Master Forge for 5 weeks, offering three different tiers, each with a different configuration. After the Kickstarter campaign finished, the Master Forge went on back-order sale on the `Forge website <https://forgekeyboard.com>`__. The following section identifies what each of these 5 bundles included. 
 
 Forge Website Pre-Orders
--------------------------
+------------------------
 The Master Forge was announced at CharaChorder's annual `ChorderCon in 2023 <https://youtu.be/fux9gU3M25E?si=WmNs4bxXJcg0JbKM>`__. It was announced alongside the Forge brand and other Forge products such as the Coder's Forge and the Gamer's Forge. After a surge in Master Forge orders, the Master Forge was given development priority. Every Master Forge order placed between November 2023 and early August 2024 includes:
 
     - :ref:`One (1) Left Digitizer<Master Forge:The Digitizers>`
@@ -659,12 +662,12 @@ The Master Forge was announced at CharaChorder's annual `ChorderCon in 2023 <htt
 
 
 Kickstarter Orders
-----------------------
+------------------
 
 The Master Forge Kickstarter campaign launched on August 27 of 2024 and closed on October 7 of 2024. The bundles offered on Kickstarter can be separated into three: Basic, Premium, and Super.  
 
 Basic
-~~~~~~
+~~~~~
 The Basic backer tier on Kickstarter includes the following:
 
     - :ref:`One (1) Left Digitizer<Master Forge:The Digitizers>`
@@ -677,7 +680,7 @@ The Basic backer tier on Kickstarter includes the following:
     - Unlimited Forge CAD Access
 
 Premium
-~~~~~~~~
+~~~~~~~
 The Premium backer tier on Kickstarter includes the following:
 
     - :ref:`One (1) Left Digitizer<Master Forge:The Digitizers>`
@@ -697,7 +700,7 @@ The Premium backer tier on Kickstarter includes the following:
 
 
 Super
-~~~~~~~
+~~~~~
 
     - :ref:`One (1) Left Digitizer<Master Forge:The Digitizers>`
     - :ref:`One (1) Right Digitizer<Master Forge:The Digitizers>`
@@ -718,7 +721,7 @@ Super
 
 
 Post-Kickstarter
------------------
+----------------
 
 Once the Kickstarter campaign ended, the Master Forge was put on sale for pre-orders on the `Forge Website <https://forgekeyboard.com>`__. Orders placed on the Forge website starting October of 2024 include:
 

--- a/docs/SerialAPI.rst
+++ b/docs/SerialAPI.rst
@@ -37,7 +37,7 @@ Commands are all caps ASCII characters. The return is always one line and includ
    ":ref:`SIM<SerialAPI:SIM>`", "Simulates/injects a chord and outputs the chord output if the chord exists in the chord library; this is primarily used for debugging."
 
 Commands
------------------
+--------
 This section covers the various commands, what they expect, what they return, and has examples of how to use them. 
 
 CMD
@@ -60,7 +60,7 @@ Example(s):
    CMD CMD,ID,VERSION,CML,VAR,RST,RAM,SIM
 
 ID
-~~~
+~~
 
 The `ID` command returns the ASCII name of the device, including the chipset code. This can be used to identify the correct serial device
 attached to the computer.
@@ -373,7 +373,7 @@ Example(s):
    VAR B2 0x15 17 0
 
 CMD_VAR_GET_KEYMAP
-^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^
 
 .. csv-table::
    :header: "I/O","Index","Name","Type","Example","Notes"
@@ -397,7 +397,7 @@ Example(s):
    VAR B3 A1 24 111 0
 
 CMD_VAR_SET_KEYMAP
-^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^
 
 .. csv-table::
    :header: "I/O","Index","Name","Type","Example","Notes"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@
    table of contents
 
 Welcome to the Official CharaChorder Guide!
-============================================
+===========================================
 
 Welcome to the wonderful world of CharaChorder! If you're here, you are likely seeking guidance for your CharaChorder device or you're simply interested in CharaChorder and came here to read a little about what CharaChorder devices are capable of. Either way, we welcome you and hope that you enjoy reading this guide. If you are setting your CharaChorder device up for the first time, please continue reading below.
 


### PR DESCRIPTION
### Fixed warnings/errors
- WARNING: Title underline too short.
- WARNING: Bullet list ends without a blank line; unexpected unindent.
- WARNING: Explicit markup ends without a blank line; unexpected unindent. [docutils]
- ERROR: Unexpected indentation. [docutils]
- WARNING: duplicate label faqs:dimensions and weight, other instance in FAQs.rst [autosectionlabel.FAQs]
- WARNING: Duplicate explicit target name: "connect button". [docutils]
- WARNING: Duplicate explicit target name: "serial port popup". [docutils]
- WARNING: Inline interpreted text or phrase reference start-string without end-string. [docutils]

### The remaining warnings are lots of these two types:
CCOS.rst:45: WARNING: unknown document: "CharaChorder's Mission" [ref.doc]
https://github.com/CharaChorder/docs/blob/c87f90b8eb4528cd8fc2e68f5345a02474c2530b/docs/CCOS.rst?plain=1#L46

CCOS.rst:65: WARNING: undefined label: 'device manager:updating your device' [ref.ref]
https://github.com/CharaChorder/docs/blob/c87f90b8eb4528cd8fc2e68f5345a02474c2530b/docs/CCOS.rst?plain=1#L67

### Notes
There were no warnings about the title underlines being too long.
The documentation for section headers says: "at least as long as the text".
> https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#sections
> Section headers ([ref](https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#sections)) are created by underlining (and optionally overlining) the section title with a punctuation character, at least as long as the text:

But the long title underlines were trimmed anyway.