### PR TITLE
Remove some startup message instructions

### DIFF
--- a/docs/CharaChorder One.rst
+++ b/docs/CharaChorder One.rst
@@ -166,29 +166,11 @@ If not done already, make sure that the USB-C side of the
 CharaChorder. It’s important to be certain that the cable is plugged all
 the way in, otherwise, the CharaChorder might not function as intended.
 
-.. warning::
-   IMPORTANT: During your first time plugging your CharaChorder in,
-   and every time thereafter when you have :ref:`realtime feedback<GenerativeTextMenu:Realtime feedback>` enabled, it’s
-   recommended that you have your cursor in a blank typing space. The
-   CharaChorder has a welcome message that can send instructions to your
-   computer that are not intended by the user. This feature can be disabled in
-   the :doc:`GTM<GenerativeTextMenu>`.
-
 After making sure that all the cables on the CharaChorder are properly
 plugged in, connect the USB-A side of the :ref:`power cable<power cable>` into
-a USB-A port on your computer. Upon connecting, you may notice the
-following things: - If your cursor is somewhere where text can be
-entered… - You will first see the text “Loading ### Chordmaps”
-highlighted, and a few moments later, “CCOS is ready.” - Regardless of
-whether or not your cursor is somewhere where text can be entered… - You
+a USB-A port on your computer. Upon connecting, you
 will be able to see a small, lime colored light inside the space that
 holds the USB-C port on the left half of the CharaChorder One.
-
-If you have :ref:`realtime feedback<GenerativeTextMenu:Realtime feedback>` enabled, once you can see the highlighted text that reads
-“CCOS is ready”, your device is ready to be used.
-
-.. note::
-   IMPORTANT: :ref:`Realtime feedback<GenerativeTextMenu:Realtime feedback>` is enabled by default on new CharaChorder devices.
 
 Getting Started
 ***************

--- a/docs/CharaChorder Two.rst
+++ b/docs/CharaChorder Two.rst
@@ -145,30 +145,9 @@ If not done already, make sure that the USB-C side of the
 CharaChorder. It’s important to be certain that the cable is plugged all
 the way in, otherwise, the CC2 might not function as intended.
 
-.. warning::
-   IMPORTANT: During your first time plugging your CharaChorder in,
-   and every time thereafter when you have :ref:`realtime feedback<GenerativeTextMenu:Realtime feedback>` enabled, it’s
-   recommended that you have your cursor in a space where you can type. The
-   CharaChorder has a welcome message that can send instructions to your
-   computer that are not intended by the user. This feature can be disabled in
-   the :doc:`GTM<GenerativeTextMenu>`.
-
 After making sure that all the cables on the CharaChorder are properly
 plugged in, connect the USB-A side of the :ref:`power cable<power cable>` into
-a USB-A port on your computer. Upon connecting, you may notice the
-following things:
-
-If your cursor is somewhere where text can be entered…
-	- You will first see the text “Loading ### Chordmaps” highlighted, and a few moments later, “CCOS is ready.”
-
-Regardless of whether or not your cursor is somewhere where text can be entered…
-	- You will be able to see a small, lime colored light inside the space that holds the USB-C port on the left half of the CC2.
-
-If you have :ref:`realtime feedback<GenerativeTextMenu:Realtime feedback>` enabled, once you can see the highlighted text that reads
-“CCOS is ready”, your device is ready to be used.
-
-.. note::
-   IMPORTANT: :ref:`Realtime feedback<GenerativeTextMenu:Realtime feedback>` is enabled by default on new CharaChorder devices.
+a USB-A port on your computer. Upon connecting, you will be able to see a small, lime colored light inside the space that holds the USB-C port on the left half of the CC2.
 
 Getting Started
 ***************

--- a/docs/CharaChorder_Lite.rst
+++ b/docs/CharaChorder_Lite.rst
@@ -130,7 +130,7 @@ If not done already, make sure that the USB-C side of the :ref:`power cable<Char
 .. note::
   The CharaChorder Lite has been sold with two different chips: M0 and S2
 
-  You can see which chip you have, by connecting to the `Device Manager <https://charachorder.io/>`__, then look at the bottom middle of the page, after the device name:
+  You can see which chip you have, by connecting to the `Device Manager <https://charachorder.io/>`__, then looking at the bottom middle of the page, after the device name:
 
     * CharaChorder Lite M0 (bought before oct 1st, 2022)
         If you have the M0 chip, continue reading the warning and instructions about the startup message below.

--- a/docs/CharaChorder_Lite.rst
+++ b/docs/CharaChorder_Lite.rst
@@ -127,7 +127,18 @@ additional software to work.
 
 If not done already, make sure that the USB-C side of the :ref:`power cable<CharaChorder_Lite:Power and Communication>` is plugged into the back right of the CharaChorder Lite. It’s important to be certain that the cable is plugged all the way in; otherwise, the CharaChorder might not function as intended.
 
-.. danger::
+.. note::
+  The CharaChorder Lite has been sold with two different chips: M0 and S2
+
+  You can see which chip you have, by connecting to the `Device Manager <https://charachorder.io/>`__, then look at the bottom middle of the page, after the device name:
+
+    * CharaChorder Lite M0 (bought before oct 1st, 2022)
+        If you have the M0 chip, continue reading the warning and instructions about the startup message below.
+
+    * CharaChorder Lite S2 (bought after oct 1st, 2022)
+        If you have the S2 chip, then you can skip to the :ref:`Getting Started section<CharaChorder_Lite:Getting Started>`, because the startup message has been removed on instant boot devices (CCOS 2.1.0).
+
+.. warning::
    By default, the device sends a :ref:`startup<GenerativeTextMenu:Startup>` message, on every boot or re-plug. In some cases, this can interfere with functions on your computer or cause unwanted behavior. This feature can be disabled in
    the :doc:`GTM<GenerativeTextMenu>`.
 

--- a/docs/Master Forge.rst
+++ b/docs/Master Forge.rst
@@ -185,24 +185,7 @@ All Forge :doc:`anchor bodies<Anchor Bodies>`, including the Master Forge Digiti
 
 If you haven't done so, now would be the time to plug the included USB-C to USB-A cable included with your order into the LEFT :doc:`digitizer<Master Forge:The Digitizers>`. If you would rather use an after-market USB-C to USB-C cable instead, due to a personal preference or computer requirement, that is also okay. Regardless of your selection, we'll refer to the cable that connects directly to the computer as the sole Power Cable. If you have any additional :doc:`bolt-ons<Bolt-Ons>`, now would be a good time to plug them into your Master.
 
-.. warning::
-   IMPORTANT: During your first time plugging your Forge in,
-   and every time thereafter when you have :doc:`realtime-feedback<GenerativeTextMenu>` enabled, it’s
-   recommended that you have your cursor in a blank typing space. :doc:`CCOS<CharaChorder Operating System (CCOS)>` devices, of which the Master Forge is one, have a welcome message that can send instructions to your
-   computer that are not intended by the user. This feature can be disabled in
-   the :doc:`GTM<GenerativeTextMenu>`.
-
-Once you have your setup connected, you can plug the Master Cable into your computer. Upon connecting, you may notice the following things:
-    If your cursor is somewhere where text can be entered…
-        - You will first see the text “Loading ### Chordmaps” highlighted, and a few moments later, “CCOS is ready.”
-    Regardless of whether or not your cursor is somewhere where text can be entered…
-        - The LED lights under your :doc:`digitizers<Digitizers>` will start their rainbow cycle.
-
-If you have :ref:`realtime feedback<GenerativeTextMenu:Realtime feedback>` enabled, once you can see the highlighted text that reads
-“CCOS is ready”, your device is ready to be used.
-
-.. note::
-   IMPORTANT: :ref:`Realtime feedback<GenerativeTextMenu:Realtime feedback>` is enabled by default on new CharaChorder devices.
+Once you have your setup connected, you can plug the Master Power Cable into your computer. Upon connecting, the LED lights under your :doc:`digitizers<Digitizers>` will start their rainbow cycle.
 
 If this is your very first time using a :doc:`CCOS<CharaChorder Operating System (CCOS)>` device, we recommend the following:
     #. Place your cursor into a place where it's safe to type


### PR DESCRIPTION
The CC Lite startup message instructions weren't removed because the CC Lite was sold with two chips: M0 and S2
A note was added, which says that S2 owners can skip the startup message instructions.

The startup message has been removed on devices with instant boot, CCOS 2.1.0+