### PR TITLE
Remove embedded action codes

### DIFF
--- a/docs/Device Manager.rst
+++ b/docs/Device Manager.rst
@@ -642,19 +642,4 @@ If you select the "Remove" button while typing a :ref:`chord output<Chords:Chord
 
 Available Action Codes
 ^^^^^^^^^^^^^^^^^^^^^^
-You can see the action codes below, or view them externally `here. <https://docs.google.com/spreadsheets/d/1--T9bXshCIC-OVly-CY3rK87fgb7AHgJl3IySh7cmHc/edit#gid=0>`__
-
-.. raw:: html
-
-    <iframe src="https://docs.google.com/spreadsheets/d/1--T9bXshCIC-OVly-CY3rK87fgb7AHgJl3IySh7cmHc/edit#gid=0" width="600" height="600"></iframe>
-
-
-
-
-
-
-
-
-
-
-
+You can view the `action codes here. <https://docs.google.com/spreadsheets/d/1--T9bXshCIC-OVly-CY3rK87fgb7AHgJl3IySh7cmHc/edit#gid=0>`__

--- a/docs/SerialAPI.rst
+++ b/docs/SerialAPI.rst
@@ -529,8 +529,4 @@ To use these chords with the Serial API, they should be converted to a 16-charac
 Action codes
 ------------
 
-You can see the action codes below, or view them externally `here. <https://docs.google.com/spreadsheets/d/1--T9bXshCIC-OVly-CY3rK87fgb7AHgJl3IySh7cmHc/edit#gid=0>`__
-
-.. raw:: html
-
-    <iframe src="https://docs.google.com/spreadsheets/d/1--T9bXshCIC-OVly-CY3rK87fgb7AHgJl3IySh7cmHc/preview" width="100%" height="600"></iframe>
+You can view the `action codes here. <https://docs.google.com/spreadsheets/d/1--T9bXshCIC-OVly-CY3rK87fgb7AHgJl3IySh7cmHc/edit#gid=0>`__


### PR DESCRIPTION
The embedded Google sheet, with the action codes, causes some issues:

On the Device Manager page:
- it scrolls to about the vertical middle when it loads
- it takes about 10 seconds to load instead of 1 second without the embed

https://github.com/user-attachments/assets/3504fc3b-fc53-4904-85f3-6fb574a97e6a

Without the embedded Google sheet:

https://github.com/user-attachments/assets/3e4eda8a-a7a6-4781-b73f-c057368414d2

The SerialAPI page also has the action codes embedded, but it's embedded as a preview. The Device Manager embedded it in edit mode (it shows the sheets menus and toolbars).

Changing the Device Manager page to an embedded preview, stops the auto scrolling, but sometimes both the Device Manager page and SerialAPI page takes a couple of seconds to load.

Another issue is that the embedded Google sheet has a fixed width, and it requires horizontal scrolling to view the last columns.


https://github.com/user-attachments/assets/2099accd-4bc6-4ce3-8d10-c8b5eaef1b53


Therefore, the embedding was removed from both the Device Manager and SerialAPI pages, leaving a link to open the action codes in a full page.