### PR TITLE
All files, trim trailing whitespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ add it to index.rst if you'd like to have it shown on the left side bar.
 
 If you'd like to link to another page (just the page) use something like this:
 ```
-:doc:`chording<Chords>` 
+:doc:`chording<Chords>`
 ```
 
 If you want to link to a specific header in another page or on the same page:

--- a/docs/Beta Releases.rst
+++ b/docs/Beta Releases.rst
@@ -6,7 +6,7 @@ Beta Releases
 
 2.2.0-beta
 **********
- 
+
 Features
 --------
 
@@ -42,7 +42,7 @@ Layer B1::
 	   any
 	any   any
 	   B3
-	
+
 	Left Middle
 	   any
 	any   any
@@ -72,14 +72,14 @@ Layer B3::
 	     any
 	any       any
 	     B3
-	
+
 	Left Thumb 1
 	     BLANK
 	BLANK     BLANK
 	     BLANK
 
 We walk forward by holding Left Thumb 1 North (``w``).
-	
+
 Reverse direction:
 
 	* We reverse direction temporarily by also holding Left Middle South (Layer B2), because it causes a repress of Left Thumb 1 North, which is now bound to ``s``.
@@ -102,37 +102,37 @@ For this to work, we need to create at least two chords:
 1. One chord that has a space between two CAPTURE actions:
 
 	.. code-block::
-	
+
 		CAPTURE CAPTURE
 
 	It restores the default behavior of adding a space after each chord:
-	
+
 	.. code-block::
-	
-		the on us 
+
+		the on us
 
 2. Another chord that has a character between the CAPTURE actions, to replace the space:
 
 	.. code-block::
-	
+
 		CAPTURE-CAPTURE
 
 	This results in:
 
 	.. code-block::
-	
+
 		the-on-us-
 
 3. Or:
 
 	.. code-block::
-	
+
 		CAPTURE_CAPTURE
 
 	Which results in:
 
 	.. code-block::
-	
+
 		the_on_us_
 
 Prepend concatenation style
@@ -180,6 +180,7 @@ The choices are:
 * 6-key
 * 12-key (default)
 * 18-key
+
 
 CC One Features
 ~~~~~~~~~~~~~~~

--- a/docs/CCOS.rst
+++ b/docs/CCOS.rst
@@ -2,68 +2,68 @@ CharaChorder Operating System (CCOS)
 ====================================
 
 **CCOS (CharaChorder Operating System)** is the world’s first operating system built
-for intelligent keyboards. The lines between what is a computer and what is an 
-input device have been blurred, and will continue to be blurred to the point 
+for intelligent keyboards. The lines between what is a computer and what is an
+input device have been blurred, and will continue to be blurred to the point
 that terminology like 'firmware' is no longer accurate or adequate.
 
-CCOS offers an unprecedented level of control, efficiency, and optimization, 
-and will be compatible with all past, present, and future CharaChorder devices, 
-as well as every device powered by :doc:`CharaChorder Engine`. CCOS guarantees 
-consistent performance across all devices and enhances the ability of our team 
-to introduce new features, fix bugs, as well as respond to feedback more 
-efficiently with a convergent and spearheaded approach. In addition to the 
-introduction of importable and exportable settings, inside your 
-:doc:`Generative Text Menu (GTM)<GenerativeTextMenu>` you'll find new 
-configurable settings including programmable debounce, arpeggiate tolerances, 
-and even a customizable scan rate. Specialized 'hard coded' chords which were 
-previously immutable can now be edited, including chords only available in 
-spurring. Even modifier keys can now be repurposed as constituent inputs for 
-any possible chord output by permanently overriding their derivative output 
-on-the-fly via :ref:`impulse<Chords:Impulse chording>`. CCOS also brings with it the introduction of advanced 
-arpeggiates, which are high staccato individual keystrokes which can enhance 
+CCOS offers an unprecedented level of control, efficiency, and optimization,
+and will be compatible with all past, present, and future CharaChorder devices,
+as well as every device powered by :doc:`CharaChorder Engine`. CCOS guarantees
+consistent performance across all devices and enhances the ability of our team
+to introduce new features, fix bugs, as well as respond to feedback more
+efficiently with a convergent and spearheaded approach. In addition to the
+introduction of importable and exportable settings, inside your
+:doc:`Generative Text Menu (GTM)<GenerativeTextMenu>` you'll find new
+configurable settings including programmable debounce, arpeggiate tolerances,
+and even a customizable scan rate. Specialized 'hard coded' chords which were
+previously immutable can now be edited, including chords only available in
+spurring. Even modifier keys can now be repurposed as constituent inputs for
+any possible chord output by permanently overriding their derivative output
+on-the-fly via :ref:`impulse<Chords:Impulse chording>`. CCOS also brings with it the introduction of advanced
+arpeggiates, which are high staccato individual keystrokes which can enhance
 chords with modifiers, prefixes, suffixes, or punctuation.
 
-If that's not exciting enough... this is only the tip of the iceberg. Here are 
-some things you can expect to experience moving forward as we peel back the 
+If that's not exciting enough... this is only the tip of the iceberg. Here are
+some things you can expect to experience moving forward as we peel back the
 layers and start to unlock the full potential of CCOS with future updates:
 
-- Compound Chording, the ability for any chord combination in any 
-  layout to be compounded with up to twelve other chords, with each compounding 
+- Compound Chording, the ability for any chord combination in any
+  layout to be compounded with up to twelve other chords, with each compounding
   layer being tied to its own unique output.
-- An interface for programming advanced keyboard/mouse macros which can be 
+- An interface for programming advanced keyboard/mouse macros which can be
   assigned to either individual switches or chord outputs
-- Soon, the only limitation for chord length will be the memory on your 
-  device due to the new CCOS architecture's capability to link together an 
+- Soon, the only limitation for chord length will be the memory on your
+  device due to the new CCOS architecture's capability to link together an
   infinite number of memory locations to a single chord output.
-- Increased independence of CharaChorder devices, including the ability of 
+- Increased independence of CharaChorder devices, including the ability of
   future generation devices to operate in the complete absence of an external computer.
-- More sophisticated mouse and cursor control, and future generation devices 
-  which function as a total mouse replacement, even for (and especially for) 
-  activities which require high precision/high speed cursor control such as 
+- More sophisticated mouse and cursor control, and future generation devices
+  which function as a total mouse replacement, even for (and especially for)
+  activities which require high precision/high speed cursor control such as
   gaming, modeling, & design.
 
 CCOS was not designed for any one product, or even for a portfolio of products.
-In alignment with our :doc:`mission<CharaChorder's Mission>` to get the whole 
-world typing at the speed of thought, CCOS was built as a platform which anyone 
-can adopt or build upon, with possibilities that are only limited by the human 
-imagination. Do you want to publish your own DataHand inspired 
-:doc:`CharaChorder One<CharaChorder One>` layout? Do you want to utilize fluid 
-chorded/character entry in tandem with layouts/theories developed for velotype 
-or stenography on your :doc:`CharaChorder Lite<CharaChorder_Lite>`? Do you want 
-to introduce the world's first 1-Dimensional keyboard layout designed for both 
-character entry and chorded entry? What about a creative combination of all of 
-the above which utilizes 100% custom hardware? No problem. This is all possible 
+In alignment with our :doc:`mission<CharaChorder's Mission>` to get the whole
+world typing at the speed of thought, CCOS was built as a platform which anyone
+can adopt or build upon, with possibilities that are only limited by the human
+imagination. Do you want to publish your own DataHand inspired
+:doc:`CharaChorder One<CharaChorder One>` layout? Do you want to utilize fluid
+chorded/character entry in tandem with layouts/theories developed for velotype
+or stenography on your :doc:`CharaChorder Lite<CharaChorder_Lite>`? Do you want
+to introduce the world's first 1-Dimensional keyboard layout designed for both
+character entry and chorded entry? What about a creative combination of all of
+the above which utilizes 100% custom hardware? No problem. This is all possible
 with CCOS.
 
-Thank you for your interest in CharaChorder OS.  We look forward to unleashing 
+Thank you for your interest in CharaChorder OS.  We look forward to unleashing
 a keyboard revolution and redefining the limits of human-computer interaction!
 
 Upgrade to CCOS
 ***************
 
 .. danger::
-    These instructions are only for those that had a device shipped before 2023 
-    and that wish to update to CCOS. For all other CCOS updates, see 
+    These instructions are only for those that had a device shipped before 2023
+    and that wish to update to CCOS. For all other CCOS updates, see
     :ref:`the device manager page<Device Manager:Updating Your Device>`.
 
 Part I - Back up chord library and update device
@@ -79,11 +79,11 @@ Part I - Back up chord library and update device
 #. Proceed with updating your device by visiting this site, choosing which device you are updating, and then proceed with Step 4. It will open a file explorer where you can find the mounted device as an external drive.  `<https://charachorder.io/ccos/>`__
 
     .. warning::
-        You'll notice that there are two different versions of the CharaChorder 
-        Lite. Please be sure to download the version that corresponds to your 
-        device, whether it's M0 or S2. If you have a CharaChorder Lite that was 
-        delivered before October 1st, 2022 you will need to use the file which 
-        corresponds to the MO chipset. Otherwise CharaChorder Lite users should 
+        You'll notice that there are two different versions of the CharaChorder
+        Lite. Please be sure to download the version that corresponds to your
+        device, whether it's M0 or S2. If you have a CharaChorder Lite that was
+        delivered before October 1st, 2022 you will need to use the file which
+        corresponds to the MO chipset. Otherwise CharaChorder Lite users should
         use the S2 chipset.
 
     .. danger::

--- a/docs/CharaChorder Engine.rst
+++ b/docs/CharaChorder Engine.rst
@@ -9,9 +9,9 @@ below to navigate to the topics that you find most relevant.
   :width: 1200
   :alt: CharaChorder Engine
 
-CharaChorder Engine is a multichip module that enables you to build your own 
+CharaChorder Engine is a multichip module that enables you to build your own
 CCOS powered text entry device. If you are interested in learning how to utilize
-CharaChorder Engine, please visit the `CharaChorder Engine Discord channel <https://discord.gg/VngNWSyZJb>`_ 
+CharaChorder Engine, please visit the `CharaChorder Engine Discord channel <https://discord.gg/VngNWSyZJb>`_
 and ping Riley Keen or Matt Swarts.
 
 .. contents:: Table of Contents of this Page
@@ -28,7 +28,7 @@ Pinout Diagram
 Design
 ******
 
-The Engine is designed primarily to work with a MCU to receive inputs (through 
+The Engine is designed primarily to work with a MCU to receive inputs (through
 UART and later I2C or SPI), process the chording logic, query the onboard chordmap
 library, and output the results back to the MCU (again over UART and later I2C or
 SPI). However, the layout of the Engine exposes USB pins, which could have a future
@@ -40,10 +40,10 @@ Physical footprint
 
 `Here is a zip file <https://drive.google.com/file/d/1B5MwTrgjcbVu-GyUrb3xXM8vcKKkh0U-/view?usp=drive_link>`__
 that contains a step file as well as KiCad files for the CharaChorder Engine
-that can be used to aid you in the design of your CCOS powered keyboard. 
+that can be used to aid you in the design of your CCOS powered keyboard.
 
 Communicating with Engine Devices
 *********************************
 
-Like other CCOS powered devices, any device with CharaChorder Engine can use the 
-full power of the :doc:`Serial API<SerialAPI>`. 
+Like other CCOS powered devices, any device with CharaChorder Engine can use the
+full power of the :doc:`Serial API<SerialAPI>`.

--- a/docs/CharaChorder One.rst
+++ b/docs/CharaChorder One.rst
@@ -43,10 +43,10 @@ The Halves
 
 Your device will come with two “halves” which comprise the full
 CharaChorder One. Each half corresponds to each hand and is designed for
-the ergonomics and comfort of each hand. The halves are injection molded ABS 
-plastic. Each half is actually two pieces which are the dome-shaped “shell” and 
-the flat and circular “baseplate”. They are held together by 5 M2, Philips screws 
-which are under the “feet” of the device. The feet are round, rubberized and help 
+the ergonomics and comfort of each hand. The halves are injection molded ABS
+plastic. Each half is actually two pieces which are the dome-shaped “shell” and
+the flat and circular “baseplate”. They are held together by 5 M2, Philips screws
+which are under the “feet” of the device. The feet are round, rubberized and help
 the device to have a grip on desks and other smooth surfaces.
 
 The left half contains the “brain” of the device, where it stores
@@ -169,10 +169,10 @@ the way in, otherwise, the CharaChorder might not function as intended.
 .. warning::
    IMPORTANT: During your first time plugging your CharaChorder in,
    and every time thereafter when you have :ref:`realtime feedback<GenerativeTextMenu:Realtime feedback>` enabled, it’s
-   recommended that you have your cursor in a blank typing space. The 
-   CharaChorder has a welcome message that can send instructions to your 
+   recommended that you have your cursor in a blank typing space. The
+   CharaChorder has a welcome message that can send instructions to your
    computer that are not intended by the user. This feature can be disabled in
-   the :doc:`GTM<GenerativeTextMenu>`. 
+   the :doc:`GTM<GenerativeTextMenu>`.
 
 After making sure that all the cables on the CharaChorder are properly
 plugged in, connect the USB-A side of the :ref:`power cable<power cable>` into
@@ -211,7 +211,7 @@ Checking your Device’s Firmware
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can check your device’s current firmware by following the steps
-below: 
+below:
 
 #. On a chromium based browser, such as Chrome, go to the CharaChorder `Device Manager <https://charachorder.io/config/layout/>`__ (Linux users see :ref:`this link<serialportaccess>` for more information about configuring serial port access.)
 #. Click “Connect” at the bottom middle of the page
@@ -234,12 +234,12 @@ Updating the Firmware
 If you find that your device is not running the latest firmware version,
 you can follow the steps below to update your device. You can check
 which is the latest firmware release by visiting `this
-site <https://charachorder.io/ccos/>`__. 
+site <https://charachorder.io/ccos/>`__.
 
 .. warning::
    IMPORTANT: Before performing the below steps, please make sure that you have a :ref:`backup of your layout<Device Manager:Backups>` as well as a :ref:`backup of your chord library<Device Manager:Backups>` and a :ref:`backup of your GTM settings<Device Manager:Backups>`. The update might reset those, so it's important that you keep backup files handy. For instructions on how to restore backed up files, visit the :ref:`Backups<Device Manager:Restoring from a Backup>` section.
 
-#. On a chromium based browser, such as Chrome, go to the CharaChorder `Device Manager <https://charachorder.io/config/layout/>`__ 
+#. On a chromium based browser, such as Chrome, go to the CharaChorder `Device Manager <https://charachorder.io/config/layout/>`__
 #. If not auto-connected, click “Connect”
 #. When the popup box comes up that reads “charachorder.io wants to connect to a serial port”, choose your CharaChorder device, then click the blue “connect” button
 #. Click on the CCOS version on the bottom left of the page
@@ -293,7 +293,7 @@ English layout, has been designed to favor :doc:`bigrams<Logic behind the Layout
    General consensus amongst the community is that, while not perfect,
    the letter arrangement of the default layout is good enough that further modifications would provide very little benefit
    considering 500+ WPM have been reached in peak conditions.
-   
+
    **Most commonly only special character and number placement is changed**, for example to benefit coding.
 
    Some exceptions include optimizing for VIM bindings, though people have successfully used the default layout for VIM as well
@@ -318,7 +318,7 @@ English layout, has been designed to favor :doc:`bigrams<Logic behind the Layout
   On the smartphone, your thumbs can type almost as fast as all of your other fingers together combined,
   and yet on a normal keyboard layout they are both tethered to a single button.
 
-  So, a design goal was to maximize left vs right hand and finger vs thumb alterations as well as 
+  So, a design goal was to maximize left vs right hand and finger vs thumb alterations as well as
   to pair the frequent keys with the ease of press-ability. This was a highly iterative process which filled up notebooks and notebooks of design sketches.
 
   In general the process that Riley used and recommends using if you would like to make your own layout is as follows:
@@ -368,7 +368,7 @@ The A2 layer, sometimes referred to as the “number layer”, is accessible
 with the :doc:`A2 access key<CharaChorder Keys>`. In the above :ref:`graphic<CCEnglish Layout>`, you’ll see this labeled
 as “num-shift.” In the `Device Manager <https://charachorder.io/config/layout/>`__,
 this key has the name “Numeric Layer (Left)” and “Numeric Layer (Right)”, one for each side of the
-CharaChorder. 
+CharaChorder.
 
 By default, the A2 Layer is accessible by pressing and holding either
 pinky finger outwards, that is, west on the left pinky or east on the

--- a/docs/CharaChorder Two.rst
+++ b/docs/CharaChorder Two.rst
@@ -148,20 +148,20 @@ the way in, otherwise, the CC2 might not function as intended.
 .. warning::
    IMPORTANT: During your first time plugging your CharaChorder in,
    and every time thereafter when you have :ref:`realtime feedback<GenerativeTextMenu:Realtime feedback>` enabled, it’s
-   recommended that you have your cursor in a space where you can type. The 
-   CharaChorder has a welcome message that can send instructions to your 
+   recommended that you have your cursor in a space where you can type. The
+   CharaChorder has a welcome message that can send instructions to your
    computer that are not intended by the user. This feature can be disabled in
-   the :doc:`GTM<GenerativeTextMenu>`. 
+   the :doc:`GTM<GenerativeTextMenu>`.
 
 After making sure that all the cables on the CharaChorder are properly
 plugged in, connect the USB-A side of the :ref:`power cable<power cable>` into
 a USB-A port on your computer. Upon connecting, you may notice the
-following things: 
+following things:
 
-If your cursor is somewhere where text can be entered… 
-	- You will first see the text “Loading ### Chordmaps” highlighted, and a few moments later, “CCOS is ready.” 
+If your cursor is somewhere where text can be entered…
+	- You will first see the text “Loading ### Chordmaps” highlighted, and a few moments later, “CCOS is ready.”
 
-Regardless of whether or not your cursor is somewhere where text can be entered… 
+Regardless of whether or not your cursor is somewhere where text can be entered…
 	- You will be able to see a small, lime colored light inside the space that holds the USB-C port on the left half of the CC2.
 
 If you have :ref:`realtime feedback<GenerativeTextMenu:Realtime feedback>` enabled, once you can see the highlighted text that reads
@@ -187,7 +187,7 @@ Checking your Device’s Firmware
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can check your device’s current firmware by following the steps
-below: 
+below:
 
 #. On a chromium based browser, such as Chrome, go to the CharaChorder `Device Manager <https://charachorder.io/config/layout/>`__ (Linux users see :ref:`this link<serialportaccess>` for more information about configuring serial port access.)
 #. Click “Connect” at the bottom middle of the page
@@ -210,12 +210,12 @@ Updating the Firmware
 If you find that your device is not running the latest firmware version,
 you can follow the steps below to update your device. You can check
 which is the latest firmware release by visiting `this
-site <https://charachorder.io/ccos/>`__. 
+site <https://charachorder.io/ccos/>`__.
 
 .. warning::
    IMPORTANT: Before performing the below steps, please make sure that you have a :ref:`backup of your layout<Device Manager:Backups>` as well as a :ref:`backup of your chord library<Device Manager:Backups>` and a :ref:`backup of your GTM settings<Device Manager:Backups>`. The update might reset those, so it's important that you keep backup files handy. For instructions on how to restore backed up files, visit the :ref:`Backups<Device Manager:Restoring from a Backup>` section.
 
-#. On a chromium based browser, such as Chrome, go to the CharaChorder `Device Manager <https://charachorder.io/config/layout/>`__ 
+#. On a chromium based browser, such as Chrome, go to the CharaChorder `Device Manager <https://charachorder.io/config/layout/>`__
 #. If not auto-connected, click “Connect”
 #. When the popup box comes up that reads “charachorder.io wants to connect to a serial port”, choose your CharaChorder device, then click the blue “connect” button
 #. Click on the CCOS version on the bottom left of the page
@@ -269,7 +269,7 @@ English layout, has been designed to favor :doc:`bigrams<Logic behind the Layout
    General consensus amongst the community is that, while not perfect,
    the letter arrangement of the default layout is good enough that further modifications would provide very little benefit
    considering 500+ WPM have been reached in peak conditions.
-   
+
    **Most commonly only special character and number placement is changed**, for example to benefit coding.
 
    Some exceptions include optimizing for VIM bindings, though people have successfully used the default layout for VIM as well
@@ -294,7 +294,7 @@ English layout, has been designed to favor :doc:`bigrams<Logic behind the Layout
   On the smartphone, your thumbs can type almost as fast as all of your other fingers together combined,
   and yet on a normal keyboard layout they are both tethered to a single button.
 
-  So, a design goal was to maximize left vs right hand and finger vs thumb alterations as well as 
+  So, a design goal was to maximize left vs right hand and finger vs thumb alterations as well as
   to pair the frequent keys with the ease of press-ability. This was a highly iterative process which filled up notebooks and notebooks of design sketches.
 
   In general the process that Riley used and recommends using if you would like to make your own layout is as follows:
@@ -344,7 +344,7 @@ The A2 layer, sometimes referred to as the “number layer”, is accessible
 with the :doc:`A2 access key<CharaChorder Keys>`. In the above :ref:`graphic<CCEnglish Layout>`, you’ll see this labeled
 as “②” In the `Device Manager <https://charachorder.io/config/layout/>`__,
 this key has the name “Numeric Layer (Left)” and “Numeric Layer (Right)”, one for each side of the
-CharaChorder. 
+CharaChorder.
 
 By default, the A2 Layer is accessible by pressing and holding either
 pinky finger outwards, that is, west on the left pinky or east on the
@@ -364,7 +364,7 @@ A3 Layer
 
 The A3 layer, sometimes referred to as the “function layer”, is
 accessible with the :ref:`A3 access key<CharaChorder Keys>`. This key is shown as ③
-in the above :ref:`graphic<CCEnglish Layout>`. It is accessible by pressing and 
+in the above :ref:`graphic<CCEnglish Layout>`. It is accessible by pressing and
 holding either pinky down, into the device. In the `Device Manager <https://charachorder.io/config/layout/>`__,
 this key has the name “Function Layer (Left)” and “Function Layer (Right)”, one for each side of the
 CharaChorder.

--- a/docs/CharaChorder X.rst
+++ b/docs/CharaChorder X.rst
@@ -8,7 +8,7 @@ Welcome to the Official CharaChorder X guide.
   :width: 1200
   :alt: CharaChorder X
 
-The CharaChorder X is a plug-and-play device that serves as a middle-man between your keyboard and your computer. It allows any keyboard to have :doc:`chording<Chords>` capabilities. Essentially, the CharaChorder X is a supersuit for your keyboard that will give it the power of :doc:`chording<Chords>`. 
+The CharaChorder X is a plug-and-play device that serves as a middle-man between your keyboard and your computer. It allows any keyboard to have :doc:`chording<Chords>` capabilities. Essentially, the CharaChorder X is a supersuit for your keyboard that will give it the power of :doc:`chording<Chords>`.
 
 What is :doc:`chording<Chords>`? Put simply, :doc:`chording<Chords>` is the action of pressing and releasing multiple keys at once to get a predetermined output. For example, we can press `b` and `c` simultaneously, and quickly release them, also simultaneously, to get the word "because". This enables you to type one word at a time, instead of one letter at a time.
 
@@ -43,7 +43,7 @@ The CharaChorder X is a single piece comprised of a circuit board which is enclo
    :widths: 25 25 25 25
    :header-rows: 1
 
-   * - 
+   * -
      - Length
      - Width
      - Height
@@ -67,7 +67,7 @@ Plugging In
 -----------
 
 The CharaChorder X is plug-and-play, so it doesn’t require any
-additional software to work. 
+additional software to work.
 
 .. warning::
    IMPORTANT: During your first time plugging your CharaChorder in,
@@ -76,15 +76,15 @@ additional software to work.
    that you have your cursor in a blank typing space. The CharaChorder
    has a welcome message that can send instructions to your computer
    that are not intended by the user. This feature can be disabled in
-   the :doc:`GTM<GenerativeTextMenu>`. 
+   the :doc:`GTM<GenerativeTextMenu>`.
 
-Take the male USB-A connector from your keyboard and plug it into the CharaChorder X's female USB-A port. After that, take the male USB'A connector on the CharaChorder X and plug it into a female USB-A port on your computer. 
+Take the male USB-A connector from your keyboard and plug it into the CharaChorder X's female USB-A port. After that, take the male USB'A connector on the CharaChorder X and plug it into a female USB-A port on your computer.
 
 Upon connecting, you may notice the
 following things:
 
 - If your cursor is somewhere where text can be entered: You will first see the text “Loading ### Chordmaps” highlighted, and a few moments later, “CCOS is ready.”
- 
+
 - Regardless of whether or not your cursor is somewhere where text can be entered: You will be able to see a small, red colored light inside the shell of the CharaChorder X.
 
 If you have :ref:`realtime feedback<GenerativeTextMenu:Realtime Feedback>` enabled, once you can see the highlighted text that reads
@@ -99,7 +99,7 @@ Getting Started
 There are a few steps that you’ll likely want to take if this is your
 first time using your CharaChorder device. In the following section, we
 will update your device, explain navigation in the :doc:`GTM<GenerativeTextMenu>`, and demonstrate the default layout on your new
-device. 
+device.
 
 Updating your Device
 --------------------
@@ -108,7 +108,7 @@ Checking your Device’s Firmware
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can check your device’s current firmware by following the steps
-below: 
+below:
 
 #. On a chromium based browser, such as Chrome, go to the CharaChorder `Device Manager <https://charachorder.io/config/layout/>`__ (Linux users see :ref:`this link<serialportaccess>` for more information about configuring serial port access.)
 #. Click “Connect” at the bottom middle of the page
@@ -131,12 +131,12 @@ Updating the Firmware
 If you find that your device is not running the latest firmware version,
 you can follow the steps below to update your device. You can check
 which is the latest firmware release by visiting `this
-site <https://charachorder.io/ccos/>`__. 
+site <https://charachorder.io/ccos/>`__.
 
 .. warning::
    IMPORTANT: Before performing the below steps, please make sure that you have a :ref:`backup of your layout<Device Manager:Backups>` as well as a :ref:`backup of your chord library<Device Manager:Backups>` and a :ref:`backup of your GTM settings<Device Manager:Backups>`. The update might reset those, so it's important that you keep backup files handy. For instructions on how to restore backed up files, visit the :ref:`Backups<Device Manager:Restoring from a Backup>` section.
 
-#. On a chromium based browser, such as Chrome, go to the CharaChorder `Device Manager <https://charachorder.io/config/layout/>`__ 
+#. On a chromium based browser, such as Chrome, go to the CharaChorder `Device Manager <https://charachorder.io/config/layout/>`__
 #. If not auto-connected, click “Connect”
 #. When the popup box comes up that reads “charachorder.io wants to connect to a serial port”, choose your CharaChorder device, then click the blue “connect” button
 #. Click on the CCOS version on the bottom left of the page
@@ -161,7 +161,7 @@ allows text entry such as a notepad app. For an explanation on chords
 and how to perform them, visit the :doc:`Chords<Chords>` section.
 
 .. warning::
-   **A bug currently exists on Windows 11 default Notepad app where chording doesn't load correctly. We are looking into this, but, for now, we recommend using a different app.** 
+   **A bug currently exists on Windows 11 default Notepad app where chording doesn't load correctly. We are looking into this, but, for now, we recommend using a different app.**
 
 Once you perform the chord to call up the :doc:`GTM<GenerativeTextMenu>`, your CharaChorder will type out the menu and its options.
 It will look something like this:
@@ -186,7 +186,7 @@ You can read an explanation on all of the settings on your CharaChorder device :
 The Layout
 ----------
 
-The CharaChorder X uses your keyboard's layout, so you don't have to learn a new one. The CharaChorder X reads the keycodes that your keyboard sends and makes use of them to produce outputs on your computer. The only drawback to this is that the CharaChorder X is unable to read keypresses that do not send a code. One common key that doesn't send a code is the Fn key. This key serves as a layer-access key, locally on your keyboard, that allows you to reach the F-keys. Although the CharaChorder X is unable to read the Fn keypress, the F-keys (F1-F24) will send out a keycode, and, thus, the CharaChorder X will send out that signal to the computer. 
+The CharaChorder X uses your keyboard's layout, so you don't have to learn a new one. The CharaChorder X reads the keycodes that your keyboard sends and makes use of them to produce outputs on your computer. The only drawback to this is that the CharaChorder X is unable to read keypresses that do not send a code. One common key that doesn't send a code is the Fn key. This key serves as a layer-access key, locally on your keyboard, that allows you to reach the F-keys. Although the CharaChorder X is unable to read the Fn keypress, the F-keys (F1-F24) will send out a keycode, and, thus, the CharaChorder X will send out that signal to the computer.
 
 Additionally, the CharaChorder X enables you to make use of two extra layers as well. In order to reach those layers, you will have to :ref:`remap<Device Manager:Remapping>` your keyboard to include the layer access keys. Nonetheless, you can continue reading below to learn how the layers work on the CharaChorder X.
 
@@ -244,7 +244,7 @@ plugged to, and it is not possible to customize their outputs.
 
 In the `Device Manager <https://charachorder.io/config/layout/>`__,
 this key has the name “Shift Keyboard Modifier (Left)” and “Shift Keyboard Modifier (Right)”, one for each side
-of the keyboard. 
+of the keyboard.
 
 The Shift is accessible by pressing the key labeled "Shift" on your keyboard. Any key
 that requires the Shift Modifier can only be accessed by pressing and
@@ -258,7 +258,7 @@ Configurability
 You can change the layout of your keyboard while it's connected to the CharaChorder X, which means that you can
 :doc:`remap<Glossary>` almost all keys. Some users may
 choose to :doc:`remap<Glossary>` their device’s layout to accommodate missing keys, such as the :doc:`DUP key<CharaChorder Keys>`. For a thorough explanation on how remapping
-works and how to remap your device, visit the :ref:`remapping section<Device Manager:Remapping>` 
+works and how to remap your device, visit the :ref:`remapping section<Device Manager:Remapping>`
 
 Practice
 ~~~~~~~~

--- a/docs/CharaChorder_Lite.rst
+++ b/docs/CharaChorder_Lite.rst
@@ -4,10 +4,10 @@ CharaChorder Lite (CCL)
 Welcome to the Official CharaChorder Lite Guide. You can select the links
 below to navigate to the topics that you find most relevant.
 
-The CharaChorder Lite is CharaChorder's approach to introducing :doc:`chording<Chords>` 
+The CharaChorder Lite is CharaChorder's approach to introducing :doc:`chording<Chords>`
 to a traditional, QWERTY keyboard. It's small, sleek, and portable, but what truly sets the "CCL" apart from other keyboards is that it's powered by :doc:`CCOS<CCOS>`. This makes the CCL a superpowered, :doc:`chording<Chords>` keyboard that may be easier to learn than the :doc:`CharaChorder One`.
 
-It boasts a beautiful set of keycaps, intentionally translucent to be able to appreciate the RGB backlights that breathe a modern look into the beautifully crafted keyboard. 
+It boasts a beautiful set of keycaps, intentionally translucent to be able to appreciate the RGB backlights that breathe a modern look into the beautifully crafted keyboard.
 
 Those who would rather build onto their muscle memory on a traditional, QWERTY keyboard can now take advantage of the CharaChorder Lite's revolutionary technology and increase their speed and efficiency.
 
@@ -83,11 +83,11 @@ The CharaChorder Lite comes with a 60% set of Gateron Clear/White switches. Thes
 .. dropdown:: What is a 60% keyboard?
 
     A 60% keyboard, also known as a "compact keyboard", is a computer keyboard that lacks a Numpad, a function row (F-Keys), and navigation keys (Home, Page Up, Page Down, etc.).
-    
+
     .. _60% Keyboard Diagram:
     .. image:: /assets/images/60%KB.jpg
       :width: 1200
-      :alt: A diagram of a 60% Keyboard 
+      :alt: A diagram of a 60% Keyboard
 
 .. note::
     Despite being a 60% keyboard, the CharaChorder Lite DOES have 4 arrow keys.
@@ -129,18 +129,18 @@ If not done already, make sure that the USB-C side of the :ref:`power cable<Char
 
 .. danger::
    By default, the device sends a :ref:`startup<GenerativeTextMenu:Startup>` message, on every boot or re-plug. In some cases, this can interfere with functions on your computer or cause unwanted behavior. This feature can be disabled in
-   the :doc:`GTM<GenerativeTextMenu>`. 
+   the :doc:`GTM<GenerativeTextMenu>`.
 
 After making sure that the cable on the CharaChorder is properly
 plugged in, connect the USB-A side of the :ref:`power cable<CharaChorder_Lite:Power and Communication>` into
 a USB-A port on your computer. Upon connecting, you may notice the
-following things: 
+following things:
 
-- If your cursor is somewhere where text can be entered… 
+- If your cursor is somewhere where text can be entered…
 
-	- You will first see the text “Loading ### Chordmaps” highlighted, and a few moments later, “CCOS is ready.” 
+	- You will first see the text “Loading ### Chordmaps” highlighted, and a few moments later, “CCOS is ready.”
 
-- Regardless of whether or not your cursor is somewhere where text can be entered… 
+- Regardless of whether or not your cursor is somewhere where text can be entered…
 
 	- You will be able to see your keyboard's lights flash from left to right, then go completely dark. After a few moments, the entire keyboard will be lit up with the LED backlighting.
 
@@ -171,7 +171,7 @@ Checking your Device’s Firmware
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can check your device’s current firmware by following the steps
-below: 
+below:
 
 #. On a chromium based browser, such as Chrome, go to the CharaChorder `Device Manager <https://charachorder.io/config/layout/>`__ (Linux users see :ref:`this link<serialportaccess>` for more information about configuring serial port access.)
 #. Click “Connect” at the bottom middle of the page
@@ -194,12 +194,12 @@ Updating the Firmware
 If you find that your device is not running the latest firmware version,
 you can follow the steps below to update your device. You can check
 which is the latest firmware release by visiting `this
-site <https://charachorder.io/ccos/>`__. 
+site <https://charachorder.io/ccos/>`__.
 
 .. warning::
    IMPORTANT: Before performing the below steps, please make sure that you have a :ref:`backup of your layout<Device Manager:Backups>` as well as a :ref:`backup of your chord library<Device Manager:Backups>` and a :ref:`backup of your GTM settings<Device Manager:Backups>`. The update might reset those, so it's important that you keep backup files handy. For instructions on how to restore backed up files, visit the :ref:`Backups<Device Manager:Restoring from a Backup>` section.
 
-#. On a chromium based browser, such as Chrome, go to the CharaChorder `Device Manager <https://charachorder.io/config/layout/>`__ 
+#. On a chromium based browser, such as Chrome, go to the CharaChorder `Device Manager <https://charachorder.io/config/layout/>`__
 #. If not auto-connected, click “Connect”
 #. When the popup box comes up that reads “charachorder.io wants to connect to a serial port”, choose your CharaChorder device, then click the blue “connect” button
 #. Click on the CCOS version on the bottom left of the page
@@ -294,7 +294,7 @@ A2 Layer
 
 The A2 layer, sometimes referred to as the “numeric layer”, is accessible
 with the :doc:`A2 access key<CharaChorder Keys>`. This key is mapped by default on the CharaChorder Lite to the keys labeled ``Fn``. In the :doc:`device manager<Device Manager>` this key has the name “KM_2_L” and “KM_2_R”, one for each side of the
-CharaChorder. 
+CharaChorder.
 
 The A2 Layer is accessible by pressing and holding either
 one of the layer access buttons. You do not have to hold them both, only one is required.
@@ -338,7 +338,7 @@ plugged to, and it is not possible to customize their outputs.
 
 On the :doc:`CharaChorder Device Manager<Device Manager>`,
 this key has the name “Left_Shift” and “Right_Shift”, one for each side
-of the CharaChorder. 
+of the CharaChorder.
 
 By default, the Shift is accessible by pressing and holding either Shift Key. You do not have to hold them both, only one is required. Any key
 that requires the Shift Modifier can only be accessed by pressing and
@@ -349,7 +349,7 @@ key is pressed while the target key is pressed.
 AltGraph Modifier
 ^^^^^^^^^^^^^^^^^
 
-While using the US INTL OS layout on your computer, you can take advantage of a modifier known as AltGraph, AltGr, or right alt. This keyboard modifier is used to provide additional graphemes for most keys. You can use the AltGraph modifier to create accented characters such as á, é, í, ó, ú, among others. 
+While using the US INTL OS layout on your computer, you can take advantage of a modifier known as AltGraph, AltGr, or right alt. This keyboard modifier is used to provide additional graphemes for most keys. You can use the AltGraph modifier to create accented characters such as á, é, í, ó, ú, among others.
 
 The AltGraph modifier output is currently controlled by the Operating System that your CharaChorder is plugged into, and it is not possible to customize their outputs. Those outputs are determined by the computer's OS.
 

--- a/docs/Chords.rst
+++ b/docs/Chords.rst
@@ -2,7 +2,7 @@ Chords
 ======
 One of CharaChorder devices’ greatest features is their
 :doc:`chording<Chords>` ability. Read this section to learn what
-chording is and how you can benefit from it on your own CharaChorder. 
+chording is and how you can benefit from it on your own CharaChorder.
 
 .. contents::  Table of Contents of this Page
    :local:
@@ -16,7 +16,7 @@ which a predefined output will replace the originally pressed keys.
 
 By chording, we are able to type one word at a time instead of one
 letter at a time. It’s even possible to have chords for phrases and
-entire sentences. 
+entire sentences.
 
 How do I use Chords?
 --------------------
@@ -24,7 +24,7 @@ How do I use Chords?
 A chord has an **input** and an **output**. We will describe what each
 of those is and how they affect chords on your CharaChorder device
 below. Throughout this guide, we might use the term “perform” when
-talking about carrying out a chord. 
+talking about carrying out a chord.
 
 .. _Chord Input:
 
@@ -39,9 +39,9 @@ to get the output “because”. In :ref:`chord notation<Chords:Chord Notation>`
 we would write that chord input as ``b+c``. Since chord inputs are
 performed simultaneously, meaning that all of the keys needed for an
 input are pressed and released at the same time, chord inputs are not
-order-specific. ``b+c`` is the same as ``c+b``. 
+order-specific. ``b+c`` is the same as ``c+b``.
 
-Chord Output 
+Chord Output
 ~~~~~~~~~~~~
 
 A chord
@@ -50,9 +50,9 @@ result after performing a chord. If we use the
 :ref:`chord input<Chords:Chord Input>` of ``b`` and ``c`` and the result is
 the word “because”, then the word “because” would be the output. In
 :ref:`chord notation<Chords:Chord Notation>`, we would write that chord (the
-input and the output) as ``b+c = because``. 
+input and the output) as ``b+c = because``.
 
-Chord Notation 
+Chord Notation
 ~~~~~~~~~~~~~~
 
 Chord
@@ -76,16 +76,16 @@ the different symbols used in chord notation in the table below.
 
 
 You can read some examples of chords written in chord notation below.
-You can try these chords on your CharaChorder device! 
+You can try these chords on your CharaChorder device!
 
 * ``y+u+o = you``
 * ``k+b+a = back``
 * ``t+o+n+d = don’t``
 * ``w+o+n+d = down``
-* ``c+b = because`` 
+* ``c+b = because``
 * ``p+m+i = important``
 
-How do I make Chords? 
+How do I make Chords?
 ---------------------
 
 You can make chords for your
@@ -101,7 +101,7 @@ can click on the link to see that list in an external tab: `Starter Chords <http
 
 You can create custom chords on the :doc:`Device Manager<Device Manager>`. Additionally, you, can create chords on the go by using
 :ref:`impulse chording<Chords:Impulse Chording>`. Read on for specific
-instructions on how to do that. 
+instructions on how to do that.
 
 On Device Manager
 ~~~~~~~~~~~~~~~~~
@@ -114,7 +114,7 @@ The process for adding chords to your CharaChorder is the same on all of
 our CharaChorder devices. You can
 :ref:`add new chords<Chords:Adding New Chords on Device Manager>`, or
 :ref:`import an existing chord library<Device Manager:Restoring from a Backup>`.
-Read how below. 
+Read how below.
 
 Adding New Chords on Device Manager
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -168,7 +168,7 @@ OUTPUT 5. CONFIRM INPUT
 6. If the input is incorrect, perform your desired input at this step.
    Once the input is the desired input, press enter.
 
-These steps should take 1-3 seconds. 
+These steps should take 1-3 seconds.
 
 Creating an Impulse Chord on the CharaChorder Lite
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -197,7 +197,7 @@ OUTPUT, 5. CONFIRM INPUT
 6. If the input is incorrect, perform your desired input at this step.
    Once the input is the desired input, press enter.
 
-These steps should take 1-3 seconds. 
+These steps should take 1-3 seconds.
 
 Creating an Impulse Chord on the CharaChorder X
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -210,7 +210,7 @@ OUTPUT, 5. CONFIRM INPUT
 .. image:: /assets/images/Impulsexgif.gif
   :width: 1200
   :alt: Impulse chording on the CharaChorder X
-  
+
 1. Anywhere that you can see a cursor, chord the input you want
    (example: ``b+u+r+s+t``). You will either see a jumble of letters
    (example: “tsubr”) or you will see a chord which is already

--- a/docs/Device Manager.rst
+++ b/docs/Device Manager.rst
@@ -3,7 +3,7 @@ Device Manager
 
 The CharaChorder Device Manager is the one-stop-shop for users with a CCOS-powered device. It boasts high quality graphics, animations and a simple user interface. On the device manager, you can change your device's :ref:`layout<Device Manager:Layout>`, manage your :ref:`chord library<Device Manager:Library>`, and adjust your :ref:`settings<Device Manager:Device>`.
 
-In this section, we'll talk about the device manager and how you can navigate around it to configure your device to your liking. First, we'll discuss the website and where to find useful buttons on it, then we'll cover the main pages on the device manager and how to use them, and, lastly, we'll touch upon some other features and useful tools on the manager. 
+In this section, we'll talk about the device manager and how you can navigate around it to configure your device to your liking. First, we'll discuss the website and where to find useful buttons on it, then we'll cover the main pages on the device manager and how to use them, and, lastly, we'll touch upon some other features and useful tools on the manager.
 
 Feel free to use the links below to skip to whatever section you would like to read or scroll to start with the first section.
 
@@ -14,12 +14,12 @@ Feel free to use the links below to skip to whatever section you would like to r
 Connecting to the Device Manager
 ********************************
 
-You can follow the steps below to connect to the device manager for the first time. 
+You can follow the steps below to connect to the device manager for the first time.
 
 .. Note::
 	If you have previously selected :ref:`Auto-connect<Autoreconnect>` within that browser for the same device, you may not need to repeat these steps every time that you go to the device manager page.
 
-1. On a chromium based browser, such as Chrome or Edge, go to the `CharaChorder Device Manager <https://charachorder.io>`__ 
+1. On a chromium based browser, such as Chrome or Edge, go to the `CharaChorder Device Manager <https://charachorder.io>`__
 2. Click “Connect” at the bottom center of the screen
 3. When the popup box comes up that reads “charachorder.io wants to connect to a serial port”, choose your CharaChorder device, then click the “Connect” button
 
@@ -27,7 +27,7 @@ You can follow the steps below to connect to the device manager for the first ti
   :width: 400
   :alt: Image showing the dialogue box requesting permission to open a serial connection
 
-If these steps were performed correctly, you can see the connected device name in the bottom bar where "Connect" was previously.  
+If these steps were performed correctly, you can see the connected device name in the bottom bar where "Connect" was previously.
 
 .. _serialportaccess:
 
@@ -35,8 +35,8 @@ Linux Serial Port Access
 ------------------------
 
 .. warning::
-    For **Linux** based users: serial port access is often restricted to specific user groups for security. 
-    To enable serial port access in a browser like Chromium, you'll need to add your user to the appropriate 
+    For **Linux** based users: serial port access is often restricted to specific user groups for security.
+    To enable serial port access in a browser like Chromium, you'll need to add your user to the appropriate
     group based on your Linux distribution.  Follow the steps below to grant access.
 
 
@@ -56,7 +56,7 @@ Replace ``$USER`` with your username or use ``$USER`` to automatically reference
 Log out and log back in for the changes to take effect.
 
 If the above commands don't work, check the group ownership of the serial device (e.g., ``/dev/ttyUSB0``) using:
-   
+
 .. code-block:: bash
 
     ls -l /dev/ttyUSB0
@@ -74,7 +74,7 @@ Log out and log back in to apply the changes. Your user will now have the necess
 Device Manager Website
 **********************
 
-The device manager comes with a navigation menu on the left hand side of the screen. 
+The device manager comes with a navigation menu on the left hand side of the screen.
 Otherwise, regardless of what page you are on, there are a few helpful buttons you should know about.
 
 Connect / Device name
@@ -89,7 +89,7 @@ Undo and Redo
   :width: 200
   :alt: The Undo and Redo arrows
 
-Near the top left corner, the device manager has handy undo and redo buttons which do exactly what their names describe. If you're making changes to your layout, your chords, or your layout, you can step back, one change at a time, all the way back to the very first change that you made during that session. Once you're stepped back, you can step forward to redo the change(s) that was/were undone. 
+Near the top left corner, the device manager has handy undo and redo buttons which do exactly what their names describe. If you're making changes to your layout, your chords, or your layout, you can step back, one change at a time, all the way back to the very first change that you made during that session. Once you're stepped back, you can step forward to redo the change(s) that was/were undone.
 
 Color Scheme
 ------------
@@ -110,7 +110,7 @@ Save Button
   :width: 200
   :alt: The Save Button
 
-If you make changes in the :ref:`library<Device Manager:Library>`, the :ref:`layout editor<Device Manager:Layout>` or the :ref:`device menu<Device Manager:Settings Menu>`, a colored "save" button will pop up on your screen, towards the top left corner. 
+If you make changes in the :ref:`library<Device Manager:Library>`, the :ref:`layout editor<Device Manager:Layout>` or the :ref:`device menu<Device Manager:Settings Menu>`, a colored "save" button will pop up on your screen, towards the top left corner.
 
 .. Note::
 	Your changes will not take effect until you click the save button.
@@ -164,7 +164,7 @@ Additionally, you can restore your chords, your layout, and your settings on the
 3. Select a file to use to restore from. This file should be in .json format.
 
 	.. note::
-		Files that you can restore from will have been created ahead of time by following the :ref:`steps to create a backup<Device Manager:Creating a Backup>`. 
+		Files that you can restore from will have been created ahead of time by following the :ref:`steps to create a backup<Device Manager:Creating a Backup>`.
 
 4. If there are changes, the :ref:`save button<Device Manager:Save Button>` will appear on the top left. Note the changes in the appropriate tab. If you restored chords, check the :ref:`chords tab<Device Manager:Chord Manager>`, if you restored a layout, check the :ref:`layout tab<Device Manager:Layout>`, and if you restored settings, check the :ref:`settings tab<Device Manager:Settings Menu>`.
 
@@ -178,10 +178,10 @@ Device Section
 
 .. _Autoreconnect:
 
-Here you'll find a helpful toggle labeled "Auto-connect". By enabling this, the device manager 
-will automatically connect your paired device through a :doc:`serial connection<SerialAPI>` 
-every time that you open it. In doing so, it will also read your chords to detect changes 
-that you may have made since the last time you connected it. If you have this enabled, 
+Here you'll find a helpful toggle labeled "Auto-connect". By enabling this, the device manager
+will automatically connect your paired device through a :doc:`serial connection<SerialAPI>`
+every time that you open it. In doing so, it will also read your chords to detect changes
+that you may have made since the last time you connected it. If you have this enabled,
 you won't have to manually connect your device to the manager ever again!
 
 
@@ -276,13 +276,13 @@ Character Entry
 ---------------
 .. dropdown:: What is Character Entry?
 
-	Character entry, known to the CharaChorder community as "chentry," refers to typing one character at time. 
+	Character entry, known to the CharaChorder community as "chentry," refers to typing one character at time.
 
 .. image:: /assets/images/ManagerSettingsChentry.png
   :width: 1200
   :alt: The Character Entry settings box
 
-In this box, you can change a few settings that relate to using your device for character entry. 
+In this box, you can change a few settings that relate to using your device for character entry.
 
 .. dropdown:: Swap Keymap 0 and 1
 
@@ -338,7 +338,7 @@ In this box, you can adjust settings relating to :doc:`CCOS'<CCOS>` mouse abilit
 
 	:doc:`CCOS<CCOS>` has two mouse speeds, a fast speed and a slow speed. The slow speed is activated when you use only one of the mouse keys in a single direction (as opposed to using 2 keys in the same direction). The fast speed is activated when you use two mouse keys in a single direction (as opposed to using only one key in the same direction).
 
-	You can read a more in-depth explanation of mouse speeds in the :ref:`GTM section<GenerativeTextMenu:Slow Speed>`. 
+	You can read a more in-depth explanation of mouse speeds in the :ref:`GTM section<GenerativeTextMenu:Slow Speed>`.
 
 .. dropdown:: Scroll Speed
 
@@ -352,7 +352,7 @@ In this box, you can adjust settings relating to :doc:`CCOS'<CCOS>` mouse abilit
 
 .. dropdown:: Poll Rate
 
-	The polling rate (poll rate) is the frequency at which data from the CharaChorder’s mouse functionality is sent to the device it’s connected to. In other words, how often it updates the cursor’s position to the computer. 
+	The polling rate (poll rate) is the frequency at which data from the CharaChorder’s mouse functionality is sent to the device it’s connected to. In other words, how often it updates the cursor’s position to the computer.
 
 	You can read a more in-depth explanation of the polling rate in the :ref:`GTM section<GenerativeTextMenu:Poll Rate>`.
 
@@ -360,7 +360,7 @@ Chording
 --------
 .. dropdown:: What is Chording?
 
-	Chording is the beautiful ability of pressing multiple keys at a time to get a predefined output, whether it's a single word, an entire phrase, or important addresses. 
+	Chording is the beautiful ability of pressing multiple keys at a time to get a predefined output, whether it's a single word, an entire phrase, or important addresses.
 
 	A chord is a type of input/output action on a keyboard: you press two or more keys at the same time and release them at the same time, after which a predefined output will replace the originally pressed keys.
 
@@ -394,7 +394,7 @@ In this box, you can adjust settings relating to :doc:`CCOS'<CCOS>` :doc:`chordi
 
 RGB
 ---
-The RGB settings ONLY affect the CharaChorder Lite as of February of 2024. 
+The RGB settings ONLY affect the CharaChorder Lite as of February of 2024.
 
 These settings adjust the color and brightness of your CharaChorder Lite.
 
@@ -421,7 +421,7 @@ You can search through your chords by searching :ref:`chord outputs<Chords:Chord
 
 To the right of the search bar, you'll find two numbers separated by a forward slash (``/``). These numbers indicate the page number that you're on out of the total number of pages that compose your chord library. Using the angle brackets to the right of those numbers will allow you to flip through the different pages of your chord library which is sorted in alphabetical order.
 
-Under the page-turning brackets, you'll see a tall box with the text "Try typing here". You can use this text box to test your new chords as you edit them in the manager. 
+Under the page-turning brackets, you'll see a tall box with the text "Try typing here". You can use this text box to test your new chords as you edit them in the manager.
 
 Under the text box if your device supports it you can find some shortcuts to help you clear your chord library, add back in the starter chords that came on your device, add functional utility chords, and download a text file with all of your chord outputs separated by a pipe character for importing into practice tools.
 
@@ -442,22 +442,22 @@ You can follow the steps below to create a new chord on the device manager.
     You will now see the :ref:`chord input<Chords:Chord Input>` in the left column as letters inside individual boxes. These boxed-letters will be highlighted in a color (as opposed to black or white). The color depends on your selected :ref:`color scheme<Device Manager:Color Scheme>`. You will also notice a single, floating dot highlighted in the same color off to the right of the boxed-letters.
 
 	.. Note::
-		You can add any number of chords at a time without defining the desired :ref:`chord output<Chords:Chord Output>`. 
+		You can add any number of chords at a time without defining the desired :ref:`chord output<Chords:Chord Output>`.
 
 	.. Warning::
 		If you click :ref:`save<Device Manager:Save Button>`, before defining a :ref:`chord output<Chords:Chord Output>` as described in :ref:`step three<Step 3>`, any chords that you've created will save to your device with a blank output and will lead to strange behavior.
 
 .. _Step 3:
 
-3. Click into the text box to the right of the :ref:`chord input<Chords:Chord Input>` that you created in the previous step and type your desired :ref:`chord output<Chords:Chord Output>`. 
+3. Click into the text box to the right of the :ref:`chord input<Chords:Chord Input>` that you created in the previous step and type your desired :ref:`chord output<Chords:Chord Output>`.
 
 	.. dropdown:: Using Action Codes
-		
+
 		As you type your :ref:`chord output<Chords:Chord Output>`, you'll notice that your cursor will have a bubble with a ``+`` above it. You can click this to open the :ref:`action codes menu<Device Manager:Using Action Codes>` where you can search for specific action codes or browse through the action codes available to assign into a :ref:`chord output<Chords:Chord Output>`. Read the :ref:`action codes section<Device Manager:Using Action Codes>` for information on the different kinds of action codes.
 
 	As you type, you'll notice that your text has changed color to match your :ref:`color scheme<Device Manager:Color Scheme>` and that the end of your text has a floating dot immediately to the right.
 
-4. Once you are satisfied with your :ref:`output<Chords:Chord Output>`, you can proceed to modify another chord or click :ref:`save<Device Manager:Save Button>`. 
+4. Once you are satisfied with your :ref:`output<Chords:Chord Output>`, you can proceed to modify another chord or click :ref:`save<Device Manager:Save Button>`.
 
 
 Deleting a Chord
@@ -476,7 +476,7 @@ You can follow the steps below to delete a chord in the device manager.
 	.. Tip::
 		You can mark multiple chords for deletion at a time. Flipping through the pages in your chord library will not unmark the chords that you have marked for deletion.
 
-3. Once you have marked the undesired chords for deletion and are ready to delete them, click the :ref:`save button<Device Manager:Save Button>`. 
+3. Once you have marked the undesired chords for deletion and are ready to delete them, click the :ref:`save button<Device Manager:Save Button>`.
 
 	Once you click save, the marked chord maps will disappear from the list.
 
@@ -493,9 +493,9 @@ You can follow the steps below to edit an existing chord in the device manager.
 2. Click the textbox in the right column where the :ref:`chord output<Chords:Chord Output>` is displayed.
 
 3. Edit the :ref:`chord output<Chords:Chord Output>` to be whatever you would like. As you type, you will notice that the text changes color to match your :ref:`color scheme<Device Manager:Color Scheme>` and that the end of your text has a floating dot immediately to the right.
-	
+
 	.. dropdown:: Using Action Codes
-		
+
 		As you type your :ref:`chord output<Chords:Chord Output>`, you'll notice that your cursor will have a bubble with a ``+`` above it. You can click this to open the :ref:`action codes menu<Device Manager:Using Action Codes>` where you can search for specific action codes or browse through the action codes available to assign into a :ref:`chord output<Chords:Chord Output>`. Read the :ref:`action codes section<Device Manager:Using Action Codes>` for information on the different kinds of action codes.
 
 	.. Tip::
@@ -507,7 +507,7 @@ You can follow the steps below to edit an existing chord in the device manager.
 
 Share button
 ------------
-Next to every chord, you will see a share icon. You can share individual chord maps with others by pressing this button. When you do, your computer's clipboard will copy a URL that you can share with anyone who can then add that exact chord map to their own CharaChorder through the Device Manager. 
+Next to every chord, you will see a share icon. You can share individual chord maps with others by pressing this button. When you do, your computer's clipboard will copy a URL that you can share with anyone who can then add that exact chord map to their own CharaChorder through the Device Manager.
 
 When you follow a chord map link, you'll be taken to the Library where you'll see the new chord map ready to be :ref:`saved<Device Manager:Save Button>`.
 
@@ -579,7 +579,7 @@ How to Remap Your Keys
 
 	.. note::
 		Your changes will not take effect until you click :ref:`save<Device Manager:Save Button>`.
-	
+
 	Once you click :ref:`save<Device Manager:Save Button>`, the highlighted key(s) will lose their highlight and the floating dot will disappear. Your layout diagram will be black and white.
 
 Using Action Codes
@@ -588,7 +588,7 @@ You can use action codes in chord outputs as well as while :ref:`remapping<Devic
 
 What are Action Codes
 ^^^^^^^^^^^^^^^^^^^^^
-Action codes are data that :doc:`CCOS<CCOS>` interprets as characters. **Put simply, they are the characters that we see while typing.** These include letters, numbers, special characters, function keys, and others. 
+Action codes are data that :doc:`CCOS<CCOS>` interprets as characters. **Put simply, they are the characters that we see while typing.** These include letters, numbers, special characters, function keys, and others.
 
 Action Code Menu
 ^^^^^^^^^^^^^^^^
@@ -598,7 +598,7 @@ You can open the action codes menu one of two ways:
 
 2. While editing your layout in the :ref:`layout editor<Device Manager:Layout>`, click on a key to bring up the action codes menu.
 
-In this menu, you can scroll through :ref:`available action codes<Device Manager:Available Action Codes>` by :ref:`category<Device Manager:Action Code Categories>`, or simply search specific actions. 
+In this menu, you can scroll through :ref:`available action codes<Device Manager:Available Action Codes>` by :ref:`category<Device Manager:Action Code Categories>`, or simply search specific actions.
 
 If you ever need to leave the action codes menu, simply click the X at the top right of the menu. This will close out the box and not make any changes.
 
@@ -634,9 +634,9 @@ There are eight different categories in the action code menu. These are: ASCII M
 
 Remove Button
 .............
-You can use the "Remove" button on the top right of the action codes menu to remove the currently assigned action code from the selected key in the :ref:`layout editor<Device Manager:Layout>`. 
+You can use the "Remove" button on the top right of the action codes menu to remove the currently assigned action code from the selected key in the :ref:`layout editor<Device Manager:Layout>`.
 
-If you select the "Remove" button while typing a :ref:`chord output<Chords:Chord Output>` in the :ref:`library<Device Manager:Library>`, it will NOT remove any action. Instead, it will add a "blank" action that will be labeled ``0x0``. 
+If you select the "Remove" button while typing a :ref:`chord output<Chords:Chord Output>` in the :ref:`library<Device Manager:Library>`, it will NOT remove any action. Instead, it will add a "blank" action that will be labeled ``0x0``.
 
 
 

--- a/docs/FAQs.rst
+++ b/docs/FAQs.rst
@@ -12,8 +12,8 @@ Where can I talk to other CharaChorder users?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Our biggest online communities are located on:
 
-- **Discord**: https://discord.gg/hYu6VW5YkM  
-- **YouTube**: https://www.youtube.com/charachorder  
+- **Discord**: https://discord.gg/hYu6VW5YkM
+- **YouTube**: https://www.youtube.com/charachorder
 
 Is it really faster than QWERTY?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -36,15 +36,15 @@ In the case of an anagramic chord, there are various workarounds, such as:
 
 Is this stenography?
 ~~~~~~~~~~~~~~~~~~~~
-It’s more like a keyboard/mouse hybrid combined with a steno writer on steroids. CharaChorder offers both high-speed character entry and ultra-high-speed chording.  
+It’s more like a keyboard/mouse hybrid combined with a steno writer on steroids. CharaChorder offers both high-speed character entry and ultra-high-speed chording.
 Videos comparing CharaChorder and stenography:
 
-- https://youtu.be/X1cUG8SWNwk?si=JM_jAeAMYqDjVtex  
-- https://youtu.be/VsG5fT5LDqU?si=Z3fYQB0MmCCxBELo  
+- https://youtu.be/X1cUG8SWNwk?si=JM_jAeAMYqDjVtex
+- https://youtu.be/VsG5fT5LDqU?si=Z3fYQB0MmCCxBELo
 
 How do I get started learning CharaChorder?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Visit the learning page at: https://www.charachorder.com/pages/learn  
+Visit the learning page at: https://www.charachorder.com/pages/learn
 
 What is the learning curve like?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -64,7 +64,7 @@ No special software is required, as the device functions as a standard keyboard.
 
 Do you have an affiliate program?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Yes! Check it out here: https://www.charachorder.com/pages/affiliate-program  
+Yes! Check it out here: https://www.charachorder.com/pages/affiliate-program
 
 CharaChorder Two FAQs
 ---------------------
@@ -74,27 +74,27 @@ The switches on a CharaChorder Two device are 3-dimensional, providing 5 unique 
 
 Dimensions and Weight CC Two
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-- **Device**: 11 ⅝" x 4 ⅜" x 1 ⅛", 10.7 oz (without USB-C), 12.1 oz (with USB-C)  
-- **Internal box/case with insert**: 12 3/16" x 8 1/16" x 2 ⅜", 15.8 oz  
-- **Final shipping box**: 13" x 9" x 2 ¾", 2.04 lbs  
-- **Half device**: 4 5/16" x 4 5/16" x 1 ⅜", 4.6 oz  
-- **Half device box only**: 5" x 5" x 5", 0.17 lb  
-- **Final half shipping box**: 5" x 5" x 5", 8.2 oz or 0.52 lbs  
+- **Device**: 11 ⅝" x 4 ⅜" x 1 ⅛", 10.7 oz (without USB-C), 12.1 oz (with USB-C)
+- **Internal box/case with insert**: 12 3/16" x 8 1/16" x 2 ⅜", 15.8 oz
+- **Final shipping box**: 13" x 9" x 2 ¾", 2.04 lbs
+- **Half device**: 4 5/16" x 4 5/16" x 1 ⅜", 4.6 oz
+- **Half device box only**: 5" x 5" x 5", 0.17 lb
+- **Final half shipping box**: 5" x 5" x 5", 8.2 oz or 0.52 lbs
 
 CharaChorder Lite FAQs
 ----------------------
 Dimensions and Weight CC Lite
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-- **Device**: 11 ⅝" (length) x 4 ⅛" (width) x 1 5/16" (height), 1 lb 0.5 oz  
-- **Case**: 14 3/16" x 6 ⅜" x 2 ⅛", 9 oz  
-- **Final shipping box**: 14 ¼" x 6 ½" x 2 ¾", 2.05 lbs  
+- **Device**: 11 ⅝" (length) x 4 ⅛" (width) x 1 5/16" (height), 1 lb 0.5 oz
+- **Case**: 14 3/16" x 6 ⅜" x 2 ⅛", 9 oz
+- **Final shipping box**: 14 ¼" x 6 ½" x 2 ¾", 2.05 lbs
 
 CharaChorder X FAQs
 -------------------
 Is there any difference between the Lite and the X?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-- **Lite**: Can handle up to 12-key singular chords.  
-- **X**: Can handle up to 6-key singular chords initially.  
+- **Lite**: Can handle up to 12-key singular chords.
+- **X**: Can handle up to 6-key singular chords initially.
 
 The Lite has special keys absent on standard keyboards, which can be remapped on the X.
 
@@ -120,10 +120,10 @@ Chords are mapped to letters, so the CCX will work with all layouts, including c
 
 How many chords come pre-loaded on the CCX?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Expect a similar number of starter chords as found in the CC Lite. 
+Expect a similar number of starter chords as found in the CC Lite.
 
-- Chord reference spreadsheet:  
-  https://docs.google.com/spreadsheets/d/1XdbJ8DmiZRKq0oUR3LSMgl9NF8cxccADXlNUnLgxvvo/  
+- Chord reference spreadsheet:
+  https://docs.google.com/spreadsheets/d/1XdbJ8DmiZRKq0oUR3LSMgl9NF8cxccADXlNUnLgxvvo/
 
 Does the X have chord modifiers like the Lite?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/GenerativeTextMenu.rst
+++ b/docs/GenerativeTextMenu.rst
@@ -5,8 +5,8 @@ Generative Text Menu (GTM)
 
 ``CharaChorder GTM [ >K<eyboard || >M<ouse || >C<hording || >D<isplay || >R<esources ]``
 
-The Generative Text Menu, known by its abbreviation as GTM, is an onboard, text based menu which can be accessed 
-anywhere you type. Through it, we are able to modify :doc:`CCOS<CCOS>` settings including :ref:`chording tolerances<GenerativeTextMenu:Press Tolerance>`, :ref:`mouse speeds<GenerativeTextMenu:Slow Speed>`, and :ref:`realtime feedback<GenerativeTextMenu:Realtime Feedback>`, among other settings and features, without the need to use a software. It's a core feature of :doc:`CCOS<CCOS>` that you will want to 
+The Generative Text Menu, known by its abbreviation as GTM, is an onboard, text based menu which can be accessed
+anywhere you type. Through it, we are able to modify :doc:`CCOS<CCOS>` settings including :ref:`chording tolerances<GenerativeTextMenu:Press Tolerance>`, :ref:`mouse speeds<GenerativeTextMenu:Slow Speed>`, and :ref:`realtime feedback<GenerativeTextMenu:Realtime Feedback>`, among other settings and features, without the need to use a software. It's a core feature of :doc:`CCOS<CCOS>` that you will want to
 learn how to use to make the device your own.
 
 You will notice that some settings have different press and release values. This is because the switches are read by the :doc:`CCOS<CCOS>` at two different moments in time: when they are pressed, and when they are released. We have designed :doc:`CCOS<CCOS>` to have configurable settings for each of those "events" separately, for maximum adjustability. Intuitively, each **press** setting, such as :ref:`debounce press<GenerativeTextMenu:Debounce Press>`, will affect the way that the :doc:`CCOS<CCOS>` reads the switch at the time that the switch is pressed into any one direction. Conversely, **release** settings, such as :ref:`release debounce<GenerativeTextMenu:Debounce Release>`, will change the way that the :doc:`CCOS<CCOS>` reads the switch at the exact moment that the switch is released, or un-pressed, from any one direction.
@@ -38,13 +38,13 @@ Use the table below to find out how to trigger the GTM for your CCOS device. Ple
 How to navigate through the GTM
 *******************************
 
-The GTM has different submenus that we can call "pages". Each "page" of the GTM will have different options which can either adjust a specific setting or take you to another submenu. 
+The GTM has different submenus that we can call "pages". Each "page" of the GTM will have different options which can either adjust a specific setting or take you to another submenu.
 
 Once you perform the chord to call up the menu, :doc:`CCOS<CCOS>` will type out the menu and its options. It will look something like this:
-	
+
 ``CharaChorder GTM [ >K<eyboard || >M<ouse || >C<hording || >D<isplay || >R<esources ]``
 
-Navigation around this menu is based on letter-presses. In the example above, you can select the desired submenu by pressing the letter that appears between the angle brackets (for example: ``>K<``) in your target submenu on your :doc:`CCOS<CCOS>` device. In the example above, you would press ``K`` for Keyboard, ``M`` for Mouse, ``C`` for Chording, ``D`` for Display, and ``R`` for Resources. In order to go back to a previous menu, press the left arrow. In order to leave the GTM at any point, press ``ESC``. Leaving the GTM by using ``ESC`` will save your changes. You can also confirm your changes by pressing ``ENTER``. 
+Navigation around this menu is based on letter-presses. In the example above, you can select the desired submenu by pressing the letter that appears between the angle brackets (for example: ``>K<``) in your target submenu on your :doc:`CCOS<CCOS>` device. In the example above, you would press ``K`` for Keyboard, ``M`` for Mouse, ``C`` for Chording, ``D`` for Display, and ``R`` for Resources. In order to go back to a previous menu, press the left arrow. In order to leave the GTM at any point, press ``ESC``. Leaving the GTM by using ``ESC`` will save your changes. You can also confirm your changes by pressing ``ENTER``.
 
 In some submenus, you will see numeric values. In order to increase or decrease these, you can use the up and down arrow keys on your :doc:`CCOS<CCOS>` device.
 
@@ -73,7 +73,7 @@ Scan Rate
 
 ``Path: GTM > Keyboard > Scan Rate``
 
-The scan rate, sometimes known as the "Key scan duration," refers to the frequency at which the device checks the state of the input keys. 
+The scan rate, sometimes known as the "Key scan duration," refers to the frequency at which the device checks the state of the input keys.
 For reference, 5 ms corresponds to 200 Hz, which means that :doc:`CCOS<CCOS>` checks the position of the keys once every 5 milliseconds, which equals 200 times in a second. Having a lower number is usually better as it makes CCOS more responsive, though the difference at low numbers is usually negligible. In the GTM, this setting is adjustable in millisecond (ms) units.
 
 You can find the default scan rates of the different CharaChorder devices in the table below.
@@ -94,7 +94,7 @@ Debounce Press
 
 ``Path: GTM > Keyboard > Debounce Press``
 
-The debounce press setting refers to the time frame (measured in milliseconds) in which  :doc:`CCOS<CCOS>` will filter out duplicate key activations on a press event. In other words, any duplicate activations within the given time frame will only be counted as one. 
+The debounce press setting refers to the time frame (measured in milliseconds) in which  :doc:`CCOS<CCOS>` will filter out duplicate key activations on a press event. In other words, any duplicate activations within the given time frame will only be counted as one.
 
 We should adjust this setting if we are having unintentional duplicate characters while typing. Increasing this value will lower the probability that unwanted duplicate characters will appear because it tells :doc:`CCOS<CCOS>` to wait longer before typing an additional character that's assigned to the same switch-direction. However, having this setting set too high might also cause issues with :doc:`CCOS<CCOS>` not reading intentional double-presses, so it's recommended to try different numbers in small increments. This setting should be used in connection with the :ref:`debounce release<GenerativeTextMenu:Debounce Release>` setting.
 
@@ -117,7 +117,7 @@ Debounce Release
 
 ``Path: GTM > Keyboard > Debounce Release``
 
-The debounce release setting refers to the time frame (measured in milliseconds) in which :doc:`CCOS<CCOS>` will filter out duplicate key activations on a release event. In other words, any duplicate activations within the given time frame will only be counted as one. 
+The debounce release setting refers to the time frame (measured in milliseconds) in which :doc:`CCOS<CCOS>` will filter out duplicate key activations on a release event. In other words, any duplicate activations within the given time frame will only be counted as one.
 
 We should adjust this setting if we are having unintentional duplicate characters while typing. Increasing this value will lower the probability that unwanted duplicate characters will appear because it tells :doc:`CCOS<CCOS>` to wait longer before typing an additional character that's assigned to the same switch-direction. However, having this setting set too high might also cause issues with :doc:`CCOS<CCOS>` not reading intentional double-presses, so it's recommended to try different numbers in small increments. This setting should be used in connection with the :ref:`debounce press <GenerativeTextMenu:Debounce Press>` setting.
 
@@ -138,11 +138,11 @@ Keystroke Delay
 
 ``Path: GTM > Keyboard > Keystroke Delay``
 
-This setting adds a small delay to keystroke inputs. It is measured in microseconds (μs) and is very small by default. 
+This setting adds a small delay to keystroke inputs. It is measured in microseconds (μs) and is very small by default.
 
-You should increase this value if your computer is not accepting all of the characters output by your device, such as when using the GTM. If you are having this issue, your GTM would look weird, with missing chunks or characters. 
+You should increase this value if your computer is not accepting all of the characters output by your device, such as when using the GTM. If you are having this issue, your GTM would look weird, with missing chunks or characters.
 
-If you have a faster computer, then you can lower this setting to make chording and the GTM feel snappier and more responsive. 
+If you have a faster computer, then you can lower this setting to make chording and the GTM feel snappier and more responsive.
 
 This value is adjusted in 40us increments. You can find the default debounce press of the different  CharaChorder devices in the table below:
 
@@ -155,13 +155,13 @@ This value is adjusted in 40us increments. You can find the default debounce pre
 +------------------+----------------+------------+-------------+--------------+
 | CharaChorder X   | 480 μs         | 0 μs       | 10200 μs    | 40 μs        |
 +------------------+----------------+------------+-------------+--------------+
- 
+
 Capslock
 ~~~~~~~~
 
 ``Path: GTM > Keyboard > Capslock``
 
-This setting is similar to a computer's Capslock: it toggles the state of the capslock. When on, all 
+This setting is similar to a computer's Capslock: it toggles the state of the capslock. When on, all
 letters output by the CCOS device will be capitalized. When off, all letters output by the CCOS device will be lowercase.
 
 Operating System
@@ -169,7 +169,7 @@ Operating System
 
 ``Path: GTM > Keyboard > Operating System``
 
-This setting refers to your host computer's operating system. Because the keys on the different computer operating systems may vary, you can set your CCOS device up so that it matches your computer. 
+This setting refers to your host computer's operating system. Because the keys on the different computer operating systems may vary, you can set your CCOS device up so that it matches your computer.
 
 Currently, on CCOS, you can select between Windows, Mac, Linux, iOS, or Android.
 
@@ -190,7 +190,7 @@ GUI-CTRL Soft Swap (CharaChorder Lite only)
 
 ``Path: GTM > Keyboard > GUI-CTRL Soft Swap``
 
-This setting will swap the behavior of the two keys on the bottom-left of the CharaChorder Lite. 
+This setting will swap the behavior of the two keys on the bottom-left of the CharaChorder Lite.
 
 Traditional QWERTY keyboards keep the ``CTRL`` key at the bottom left corner of the keyboard with the ``GUI`` key (Command key on Mac, Windows key on Windows, Super key on Linux, etc.) to the right of the ``CTRL`` key. The CharaChorder Lite has these two keys swapped by default, which some users find odd and difficult to adjust to. A brand new CharaChorder Lite will have the ``GUI`` key at the bottom-left corner with the ``CTRL`` key to the right of the ``GUI`` key.
 
@@ -233,7 +233,7 @@ However, :doc:`CCOS<CCOS>` uses ms (milliseconds) which is directly inverse to H
     In the context of frequency and period (time duration), the relationship is inverse. Frequency is the number of cycles per second, measured in Hz. The period is the time it takes for one cycle to complete, measured in seconds (s). The formula is:
 
 	``Frequency (Hz) = 1/Period (s), where s = 1000 ms``
- 
+
     If you convert the period to milliseconds (ms), the relationship remains inverse. For instance, if you have a frequency of 1000 Hz, the period is 1 ms (because 1 second = 1000 milliseconds). As the frequency increases, the period (measured in ms) decreases.
 
 
@@ -254,13 +254,13 @@ Slow Speed
 
 ``Path: GTM > Mouse > Slow Speed``
 
-Slow speed is activated when you use only one of the mouse keys in a single direction (as opposed to using 2 keys in the same direction). Increasing this setting will make your CCOS pointer move faster. 
+Slow speed is activated when you use only one of the mouse keys in a single direction (as opposed to using 2 keys in the same direction). Increasing this setting will make your CCOS pointer move faster.
 
 This setting is used in conjunction with :ref:`poll rate <GenerativeTextMenu:Poll Rate>`. See the explanation below.
 
 .. dropdown:: Explanation of CCOS mouse speeds
 
-    The mouse speed refers to the speed of the cursor on the CharaChorder's mouse functionality. The cursor will move at the number of pixels (px) indicated by this setting multiplied by the number of Hz indicated by the :ref:`polling rate<GenerativeTextMenu:Poll Rate>`. 
+    The mouse speed refers to the speed of the cursor on the CharaChorder's mouse functionality. The cursor will move at the number of pixels (px) indicated by this setting multiplied by the number of Hz indicated by the :ref:`polling rate<GenerativeTextMenu:Poll Rate>`.
 
     In other words, if your speed is set to 2 px, and your :ref:`poll rate<GenerativeTextMenu:Poll Rate>` is set to 20 ms (~50 Hz), your CharaChorder's cursor will move at 100 pixels per second (px/s). The equation comes out to:
     ``Speed (px) x poll rate (Hz) = Number of pixels that the cursor will move per second``
@@ -280,13 +280,13 @@ Fast Speed
 
 ``Path: GTM > Mouse > Fast Speed``
 
-Fast speed is activated when you use two mouse keys in a single direction (as opposed to using only one key in the same direction). Increasing this setting will make your CCOS pointer move faster. 
+Fast speed is activated when you use two mouse keys in a single direction (as opposed to using only one key in the same direction). Increasing this setting will make your CCOS pointer move faster.
 
 This setting is used in conjunction with :ref:`poll rate <GenerativeTextMenu:Poll Rate>`. See the explanation below.
 
 .. dropdown:: Explanation of CCOS mouse speeds
 
-    The mouse speed refers to the speed of the cursor on the CharaChorder's mouse functionality. The cursor will move at the number of pixels (px) indicated by this setting multiplied by the number of Hz indicated by the :ref:`polling rate<GenerativeTextMenu:Poll Rate>`. 
+    The mouse speed refers to the speed of the cursor on the CharaChorder's mouse functionality. The cursor will move at the number of pixels (px) indicated by this setting multiplied by the number of Hz indicated by the :ref:`polling rate<GenerativeTextMenu:Poll Rate>`.
 
     In other words, if your speed is set to 2 px, and your :ref:`poll rate<GenerativeTextMenu:Poll Rate>` is set to 20 ms (~50 Hz), your CharaChorder's cursor will move at 100 pixels per second (px/s). The equation comes out to:
     ``Speed (px) x poll rate (Hz) = Number of pixels that the cursor will move per second``
@@ -306,13 +306,13 @@ Scroll Speed
 
 ``Path: GTM > Mouse > Scroll Speed``
 
-Scroll speed refers to the speed at which your CCOS scroll will scroll. 
+Scroll speed refers to the speed at which your CCOS scroll will scroll.
 
 Increasing this setting will make your CCOS scrolling scroll faster. This setting is used in conjunction with :ref:`poll rate <GenerativeTextMenu:Poll Rate>`. See the explanation below.
 
 .. dropdown:: Explanation of CCOS mouse speeds
 
-    The scroll speed refers to the speed at which the CharaChorder scrolls at. The CCOS will scroll at the number of pixels (px) indicated by this setting multiplied by the number of Hz indicated by the :ref:`polling rate<GenerativeTextMenu:Poll Rate>`. 
+    The scroll speed refers to the speed at which the CharaChorder scrolls at. The CCOS will scroll at the number of pixels (px) indicated by this setting multiplied by the number of Hz indicated by the :ref:`polling rate<GenerativeTextMenu:Poll Rate>`.
 
     In other words, if your speed is set to 2 px, and your :ref:`poll rate<GenerativeTextMenu:Poll Rate>` is set to 20 ms (~50 Hz), your CharaChorder's scroll will move at 100 pixels per second (px/s). The equation comes out to:
     ``Speed (px) x poll rate (Hz) = Number of pixels that the cursor will move per second``
@@ -348,9 +348,9 @@ Character Only Mode
 
 This setting is a toggle that disables chording capabilities on CCOS devices. It is off by default and can be enabled in case we don't want any chording at all. This setting can be useful in cases where we don't want to accidentally trigger chords unintentionally, such as when gaming.
 
-If your CCOS device suddenly loses its chording ability, it's a good idea to check if this setting is toggled off. 
+If your CCOS device suddenly loses its chording ability, it's a good idea to check if this setting is toggled off.
 
-Press Tolerance 
+Press Tolerance
 ~~~~~~~~~~~~~~~
 
 ``Path: GTM > Chording > Press Tolerance``
@@ -441,9 +441,9 @@ Spurring
 
 ``Path: GTM > Chording > Spurring``
 
-A 'chording only' mode which tells your device to output chords on a press event rather than a press & release and release event. When in spurring mode, you can press the keys of a chord one at a time with a much longer waiting period, which makes it a useful mode for those who want to practice chording without worrying about proper :ref:`timing<GenerativeTextMenu:Press Tolerance>`. 
+A 'chording only' mode which tells your device to output chords on a press event rather than a press & release and release event. When in spurring mode, you can press the keys of a chord one at a time with a much longer waiting period, which makes it a useful mode for those who want to practice chording without worrying about proper :ref:`timing<GenerativeTextMenu:Press Tolerance>`.
 
-Spurring mode also enables you to jump from one chord to another without releasing everything. It can provide significant speed gains when chording, but also takes away the flexibility of character entry. Spurring mode can truly maximize speed when chording if a user has chords for all of the words they want to use. 
+Spurring mode also enables you to jump from one chord to another without releasing everything. It can provide significant speed gains when chording, but also takes away the flexibility of character entry. Spurring mode can truly maximize speed when chording if a user has chords for all of the words they want to use.
 
 Spurring On/Off
 ^^^^^^^^^^^^^^^
@@ -476,14 +476,14 @@ Arpeggiate
 Arpeggiate actions are timed actions that can modify a chord after the chord is performed. A quick example of this is the use of chord modifiers after you perform the chord. You can read that section for information on how the :doc:`chord modifiers<Chord Modifiers>` work.
 
 With arpeggiates enabled, you can chord the word ``run`` and then, within the :ref:`arpeggiate timeout window<GenerativeTextMenu:Arpeggiate Timeout>`, press the past tense modifier for the word to be "modified" into its past tense variant; in english, ``ran``.
- 
+
 
 Arpeggiate On/Off
 ^^^^^^^^^^^^^^^^^
 
 ``Path: GTM > Chording > Arpeggiate > Arpeggiate On/Off``
 
-This setting will let you toggle the arpeggiate capability ON or OFF. 
+This setting will let you toggle the arpeggiate capability ON or OFF.
 
 Some users dislike arpeggiates as, in really fast typing, it may cause unwanted modifications.
 
@@ -492,7 +492,7 @@ Arpeggiate Timeout
 
 ``Path: GTM > Chording > Arpeggiate > Arpeggiate Timeout``
 
-The arpeggiate timeout is a window of time after a chord is performed during which CCOS will expect arpeggiates to be performed. After this timer runs out, CCOS will NO LONGER modify the preceding chord. 
+The arpeggiate timeout is a window of time after a chord is performed during which CCOS will expect arpeggiates to be performed. After this timer runs out, CCOS will NO LONGER modify the preceding chord.
 
 A common issue that users may run into while having arpeggiates enabled is the shift key modifying the preceding chord instead of the next key. For this reason, some users lower the arpeggiate timeout to a really low amount of time in order to reduce the possibility of this happening unintentionally.
 
@@ -513,7 +513,7 @@ Realtime Feedback
 
 ``Path: GTM > Display > Realtime Feedback``
 
-This setting toggles realtime feedback ON or OFF. 
+This setting toggles realtime feedback ON or OFF.
 
 Realtime feedback refers to the helpful text like ``SPURRING_ON``, ``SPURRING_OFF`` etc, that lets the user know if a certain mode has been activated or deactivated on the CharaChorder device. Since there is no other visual way to know if the chord used to enable or disable certain settings, it is helpful to have these texts pop up as confirmation.
 
@@ -551,7 +551,7 @@ On/Off
 
 Quickly toggle the LEDs on or off with this setting.
 
-Color 
+Color
 ^^^^^
 
 ``Path: GTM > Display > LEDs > Color``
@@ -600,7 +600,7 @@ Resources
 
 ``Path: GTM > Resources``
 
-This section contains links which may be helpful to you. These links include: 
+This section contains links which may be helpful to you. These links include:
 
 .. csv-table::
     :header: "Letter", "Item", "Description"

--- a/docs/Glossary.rst
+++ b/docs/Glossary.rst
@@ -1,36 +1,36 @@
 Glossary
 ========
 
-Below you will find some common "uncommon" words that are used in the CharaChorder 
-community. 
+Below you will find some common "uncommon" words that are used in the CharaChorder
+community.
 
 .. glossary::
    :sorted:
 
    3D Press
-      When a switch is activated by pushing it normal to the surface of the 
+      When a switch is activated by pushing it normal to the surface of the
       device (same as an ordinary keyboard switch).
 
    Active Mode
-      Nudges your mouse one pixel every minute or so to keep your computer 
+      Nudges your mouse one pixel every minute or so to keep your computer
       from sleeping.
-    
+
    Ambidextrous Throwover (aka Mirror Mode)
-      Entry mode designed for one-handed typing. Characters from the opposite 
+      Entry mode designed for one-handed typing. Characters from the opposite
       hand are mirrored to the hand which activates this feature.
 
    Arpeggiate
       A quick, single key press and release to indicate a suffix, prefix, or
       modifier to be associated with a chord.
-   
+
    Chentry
       Shorthand for 'character entry', or typing on a chording-enabled device
       letter by letter.
-      
+
    Chord Modifiers
       Inputs which, when included with a chord, change the prefix, suffix,
-      capitalization, conjugation, part of speech, language, or structure of a chord.  Note, these can be used arpeggiately. 
-      
+      capitalization, conjugation, part of speech, language, or structure of a chord.  Note, these can be used arpeggiately.
+
    Compound Chords
       Multiple chords which behave differently when used together in context
       (not yet user programmable). Example: know + ledge = knowledge.
@@ -49,11 +49,11 @@ community.
 
    Fluid Chorded/Character Entry
       Default text entry mode for CharaChorder. Output characters individually
-      (like a keyboard) OR press and release multiple characters of a chord 
+      (like a keyboard) OR press and release multiple characters of a chord
       simultaneously to output a chord.
 
    GTM (Generative Text Menu)
-      A text-based menu accessible anywhere you type. It allows access to 
+      A text-based menu accessible anywhere you type. It allows access to
       various device settings and features without software. See :doc:`GenerativeTextMenu`.
 
    Impulse Chord
@@ -65,8 +65,8 @@ community.
 
    Spurring
       A 'chording only' mode which outputs chords on a press rather than a
-      press & release. Enables jumping from one chord to another without 
-      releasing everything. It can provide significant speed gains with chording, 
-      but also takes away the flexibility of character entry. Spurring also 
-      helps new users learn how to chord by eliminating the need to focus on 
+      press & release. Enables jumping from one chord to another without
+      releasing everything. It can provide significant speed gains with chording,
+      but also takes away the flexibility of character entry. Spurring also
+      helps new users learn how to chord by eliminating the need to focus on
       timing.

--- a/docs/Layout.rst
+++ b/docs/Layout.rst
@@ -11,7 +11,7 @@ TL;DR, so what does this mean for me?
 
 First of all, here are some pitfalls
 
-* If you set for example `$`, the CCOS types this as "hold shift press 4 release shift". 
+* If you set for example `$`, the CCOS types this as "hold shift press 4 release shift".
   Meaning if you press `$` and `3` together, **you'll actually type "$#" instead of "$3"**
   because the CCOS needs to hold shift for typing the `$` sign
   - *Avoid putting characters that need shift and normal characters on the same layer*
@@ -41,9 +41,9 @@ There is no standard for other typing input devices,  nor is there a way for the
 How does CharaChorder deal with this?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If you set a layout on the CCOS, it moves the key-code locations around. 
+If you set a layout on the CCOS, it moves the key-code locations around.
 
-.. warning:: 
+.. warning::
   Setting the letter `a` on a switch doesn't actually send "print a" to the computer - it sends a "key where the a would be on the us layout pressed" to the OS**.
 
 So how can I add äöüß etc when it's not on the US layout?

--- a/docs/Master Forge.rst
+++ b/docs/Master Forge.rst
@@ -46,7 +46,7 @@ The Digitizers
 Your device will come with two Digitizers which, together, comprise the Master Forge. Each digitizer typically corresponds to each hand and is designed for the ergonomics and comfort of each hand. The digitizers are composed of a 3D printed endoskeleton and a machined-aluminum exoskeleton. The exoskeleton of the digitizer is actually two pieces which are the trapezoidal-shaped “shell,” and the flat and partially hollowed out “baseplate”. They are held together by five M2, Philips screws which are
 under the “feet” pads of the device. The feet are round, rubberized and help the device to have a grip on desks and other smooth surfaces.
 
-There are two different kinds of digitizers, each of which can be purchased individually; the left digitizer and the right digitizer. Each one contains a :doc:`Platinum CharaChorder Core<CharaChorder Core>` where they store chords, layouts, and settings. 
+There are two different kinds of digitizers, each of which can be purchased individually; the left digitizer and the right digitizer. Each one contains a :doc:`Platinum CharaChorder Core<CharaChorder Core>` where they store chords, layouts, and settings.
 
 The front of each digitizer has a slotted rail which allows :doc:`bolt-ons<Bolt-Ons>` to be "bolted" onto the digitizer. An example of a :doc:`bolt-on<Bolt-Ons>` is the :ref:`bridge connector<The Bridge Connector>`. Along this slotted rail you'll find two USB-C ports on each digitizer, one at the exterior edge of each "shoulder."
 
@@ -55,14 +55,14 @@ The front of each digitizer has a slotted rail which allows :doc:`bolt-ons<Bolt-
   :width: 1200
   :alt: Picture showing the bridge connector and the ports
 
-The underside of the each digitizer is partially hollow to allow for cables and connections to happen in a discreet manner underneath the device. Inside the cavity, we can find two additional USB-C ports and downward facing LED clusters. 
+The underside of the each digitizer is partially hollow to allow for cables and connections to happen in a discreet manner underneath the device. Inside the cavity, we can find two additional USB-C ports and downward facing LED clusters.
 
 .. _M4G Below:
 .. image:: /assets/images/M4G-Under.webp
   :width: 1200
   :alt: Bottom side of the Master Forge
 
-On the sides of each digitizer, you'll notice the :ref:`bookend rails<The Bookend Rails>`. Under each rail, on the body of the digitizer, you'll see holes for the screws that hold the bookend rails in place. 
+On the sides of each digitizer, you'll notice the :ref:`bookend rails<The Bookend Rails>`. Under each rail, on the body of the digitizer, you'll see holes for the screws that hold the bookend rails in place.
 
 .. _M4G Side:
 .. image:: /assets/images/M4G-Side.webp
@@ -72,7 +72,7 @@ On the sides of each digitizer, you'll notice the :ref:`bookend rails<The Booken
 The Bridge Connector
 ~~~~~~~~~~~~~~~~~~~~
 
-Out of the box, your :ref:`digitizers<The Digitizers>` will be connected by a mechanical bridge :doc:`bolt-on<Bolt-Ons>`. This :doc:`bolt-on<Bolt-Ons>` is also machined-aluminum and made from a slotted rail. It's held in place by two, M3 nylon screws. Nylon screws don't "set" into the aluminum like steel screws, which prevents damage to the slotted rails, since the slotted rails at the front of the device don't have any holes for screws to go into. It's more of a friction hold, which is a key concept of :doc:`bolt-ons<Bolt-Ons>`. 
+Out of the box, your :ref:`digitizers<The Digitizers>` will be connected by a mechanical bridge :doc:`bolt-on<Bolt-Ons>`. This :doc:`bolt-on<Bolt-Ons>` is also machined-aluminum and made from a slotted rail. It's held in place by two, M3 nylon screws. Nylon screws don't "set" into the aluminum like steel screws, which prevents damage to the slotted rails, since the slotted rails at the front of the device don't have any holes for screws to go into. It's more of a friction hold, which is a key concept of :doc:`bolt-ons<Bolt-Ons>`.
 
 .. _M4G Bridge Connector:
 .. image:: /assets/images/Bridge.webp
@@ -82,26 +82,26 @@ Out of the box, your :ref:`digitizers<The Digitizers>` will be connected by a me
 Additionally, the two :ref:`digitizers<The Digitizers>` are connected by the electrical bridge connector, also known as the mini-connector. This piece fits inside the cavity of the :ref:`mechanical bridge connector<Mechanical Bridge Connector>` and should be removed BEFORE removing the mechanical bridge connector.
 
 .. note::
-    When separating the digitizers, the :ref:`electrical bridge connector<Electrical Bridge Connector>` should be removed before the :ref:`mechanical bridge connector<Mechanical Bridge Connector>`. 
+    When separating the digitizers, the :ref:`electrical bridge connector<Electrical Bridge Connector>` should be removed before the :ref:`mechanical bridge connector<Mechanical Bridge Connector>`.
 
     Similarly, when putting the digitizers together again, they should be assembled in reverse order of how they were disassembled; that is, the :ref:`mechanical bridge connector<Mechanical Bridge Connector>` should be secured into place before pressing the :ref:`electrical bridge connector<Electrical Bridge Connector>` into place.
 
 
-The electrical bridge connector is a thin printed circuit board that ends in a USB-C plug on either side. This makes it so that the front right port of the left digitizer feeds into the front left port of the right digitizer. 
+The electrical bridge connector is a thin printed circuit board that ends in a USB-C plug on either side. This makes it so that the front right port of the left digitizer feeds into the front left port of the right digitizer.
 
 When connected by the official Forge bridge connector, the left digitizer should be the one connected directly to your computer. See :ref:`Getting Started<tag?>` for more information about this.
 
 The Bookend Rails
 ~~~~~~~~~~~~~~~~~
 
-Each :ref:`digitizer<The Digitizers>` of the Master Forge comes with three removable bookend rails. These rails are what allow the digitizers to attach to other :doc:`anchor bodies<Anchor Bodies>` and :ref:`bolt-ons<Bolt-Ons>`. 
+Each :ref:`digitizer<The Digitizers>` of the Master Forge comes with three removable bookend rails. These rails are what allow the digitizers to attach to other :doc:`anchor bodies<Anchor Bodies>` and :ref:`bolt-ons<Bolt-Ons>`.
 
 .. _M4G Rails:
 .. image:: /assets/images/Rails.webp
   :width: 1200
   :alt: The three Bookend Rails
 
-The bookend rails are made of machined aluminum and are held in place on the body of the :ref:`digitizers<The Digitizers>` by two (size), steel screws. 
+The bookend rails are made of machined aluminum and are held in place on the body of the :ref:`digitizers<The Digitizers>` by two (size), steel screws.
 
 The Splitter
 ~~~~~~~~~~~~
@@ -125,9 +125,9 @@ Each :ref:`digitizer<The Digitizers>` has eight 5-way switches. Starting from th
    **IMPORTANT**: In this manual, we will refer to switches in the
    following way, starting from the pinky finger and working inwards:
    pinky, ring, middle, index, thumb 1, and thumb 2. The
-   switches below the “home-row” will be referred to as the aux 1 and aux 2    
+   switches below the “home-row” will be referred to as the aux 1 and aux 2
    switches, where the switch further to the left on the left digitizer
-   is aux 1. Symmetrically, aux 1 is the switch furthest to the right on the 
+   is aux 1. Symmetrically, aux 1 is the switch furthest to the right on the
    right half.
 
 Each switch has five press-able directions. Throughout this guide, we
@@ -146,12 +146,12 @@ switch can be pressed down, into the device. We often refer to this
 press as a 3D press, since it’s not a lateral movement, but rather a
 movement along the Z axis of the switch. This special press requires no
 lateral movement in order to work, just apply force onto the switch
-“into” the device. 
+“into” the device.
 
 The four cardinal directions on a switch can be mapped
 to a configurable key, which can include letters, numbers, symbols,
 control keys and even function keys. You can see the most current list
-of configurable action codes in the `Device Manager <https://manager.charachorder.com/config/layout/>`__. The 3D press cannot be assigned to an individual character, but, instead, allows you to press all four cardinal directions on a switch simultaneously, as a :doc:`chord<Chording>`. 
+of configurable action codes in the `Device Manager <https://manager.charachorder.com/config/layout/>`__. The 3D press cannot be assigned to an individual character, but, instead, allows you to press all four cardinal directions on a switch simultaneously, as a :doc:`chord<Chording>`.
 
 Connections
 -----------
@@ -167,35 +167,35 @@ cable that goes out to the computer inside the box. The power cable included wit
 Another cable that may be included with your order is a 3.2 gen 2, braided USB-C to USB-C cable. This cord is meant to be used if you choose to separate your :ref:`digitizers<The Digitizers>`.
 
 .. dropdown:: Things to remember if you separate your digitizers
-    
-    There are two main things to remember if you choose to use your Master Forge separated: 
+
+    There are two main things to remember if you choose to use your Master Forge separated:
         1. The cable that you use to connect the digitizers must be a 3.2 gen 2, C to C cable.
-        2. As pointed out in the :ref:`getting started section<Port Requirement>` of this page, power to an :doc:`anchor body<Anchor Bodies>` or :ref:`bolt-on<Bolt-Ons>` must be received through the front left USB-C port. This means that every anchor body or bolt-on that you add to your system has to be linked to the Master through the port on the front left.   
+        2. As pointed out in the :ref:`getting started section<Port Requirement>` of this page, power to an :doc:`anchor body<Anchor Bodies>` or :ref:`bolt-on<Bolt-Ons>` must be received through the front left USB-C port. This means that every anchor body or bolt-on that you add to your system has to be linked to the Master through the port on the front left.
 
 Getting Started
 ***************
 
 The Master Forge is plug-and-play, so it doesn’t require any
 additional software to work. Before plugging your Forge in for
-the first time, it’s important to make sure that either the :ref:`electrical bridge connector<Master Forge:The Bridge Connector>` or a USB-C cable is correctly plugged into both :ref:`digitizers<Master Forge:The Digitizers>`. 
+the first time, it’s important to make sure that either the :ref:`electrical bridge connector<Master Forge:The Bridge Connector>` or a USB-C cable is correctly plugged into both :ref:`digitizers<Master Forge:The Digitizers>`.
 
 .. _Port Requirement:
 
 All Forge :doc:`anchor bodies<Anchor Bodies>`, including the Master Forge Digitizers, should be connected to a power source through their front, left USB-C port. It's important to use that specific port to connect your device to your computer because no other port will permit your Forge to function correctly. As a rule of thumb, all Forge :doc:`anchor bodies<Anchor Bodies>` must receive power through their front, left port. The other three ports are outgoing ports in order to connect other :doc:`anchor bodies<Anchor Bodies>` and :doc:`bolt-ons<Bolt-Ons>`. Each additional :doc:`anchor body<Anchor Bodies>` or :doc:`bolt-on<Bolt-Ons>` will need to "receive" power from the "Master" :doc:`anchor body<Anchor Bodies>`, or from an :doc:`anchor body<Anchor Bodies>` or :doc:`bolt-on<Bolt-Ons>` connected to the Master. A "Master" :doc:`anchor body<Anchor Bodies>` is the one connected directly to your computer. Please note that some :doc:`bolt-ons<Bolt-Ons>` may function as a Master.
 
-If you haven't done so, now would be the time to plug the included USB-C to USB-A cable included with your order into the LEFT :doc:`digitizer<Master Forge:The Digitizers>`. If you would rather use an after-market USB-C to USB-C cable instead, due to a personal preference or computer requirement, that is also okay. Regardless of your selection, we'll refer to the cable that connects directly to the computer as the sole Power Cable. If you have any additional :doc:`bolt-ons<Bolt-Ons>`, now would be a good time to plug them into your Master. 
+If you haven't done so, now would be the time to plug the included USB-C to USB-A cable included with your order into the LEFT :doc:`digitizer<Master Forge:The Digitizers>`. If you would rather use an after-market USB-C to USB-C cable instead, due to a personal preference or computer requirement, that is also okay. Regardless of your selection, we'll refer to the cable that connects directly to the computer as the sole Power Cable. If you have any additional :doc:`bolt-ons<Bolt-Ons>`, now would be a good time to plug them into your Master.
 
 .. warning::
    IMPORTANT: During your first time plugging your Forge in,
    and every time thereafter when you have :doc:`realtime-feedback<GenerativeTextMenu>` enabled, it’s
-   recommended that you have your cursor in a blank typing space. :doc:`CCOS<CharaChorder Operating System (CCOS)>` devices, of which the Master Forge is one, have a welcome message that can send instructions to your 
+   recommended that you have your cursor in a blank typing space. :doc:`CCOS<CharaChorder Operating System (CCOS)>` devices, of which the Master Forge is one, have a welcome message that can send instructions to your
    computer that are not intended by the user. This feature can be disabled in
-   the :doc:`GTM<GenerativeTextMenu>`. 
+   the :doc:`GTM<GenerativeTextMenu>`.
 
-Once you have your setup connected, you can plug the Master Cable into your computer. Upon connecting, you may notice the following things: 
-    If your cursor is somewhere where text can be entered… 
-        - You will first see the text “Loading ### Chordmaps” highlighted, and a few moments later, “CCOS is ready.” 
-    Regardless of whether or not your cursor is somewhere where text can be entered… 
+Once you have your setup connected, you can plug the Master Cable into your computer. Upon connecting, you may notice the following things:
+    If your cursor is somewhere where text can be entered…
+        - You will first see the text “Loading ### Chordmaps” highlighted, and a few moments later, “CCOS is ready.”
+    Regardless of whether or not your cursor is somewhere where text can be entered…
         - The LED lights under your :doc:`digitizers<Digitizers>` will start their rainbow cycle.
 
 If you have :ref:`realtime feedback<GenerativeTextMenu:Realtime feedback>` enabled, once you can see the highlighted text that reads
@@ -207,18 +207,18 @@ If you have :ref:`realtime feedback<GenerativeTextMenu:Realtime feedback>` enabl
 If this is your very first time using a :doc:`CCOS<CharaChorder Operating System (CCOS)>` device, we recommend the following:
     #. Place your cursor into a place where it's safe to type
     #. Place your hands on the :doc:`digitizers<Master Forge:The Digitizers>` and nestle your fingers on the switches
-    #. Move your index, middle, and ring fingers southwards, towards your body, one at a time. 
+    #. Move your index, middle, and ring fingers southwards, towards your body, one at a time.
 
-These directions correspond to the letters U, O, E, T, N, and S. Now, let's try a :doc:`chord<Chording>`. 
+These directions correspond to the letters U, O, E, T, N, and S. Now, let's try a :doc:`chord<Chording>`.
 
-.. dropdown:: How to perform a Chord? 
+.. dropdown:: How to perform a Chord?
 
-    A chord is a type of input that allows you to press multiple keys at a time in order to achieve a predetermined :ref:`output<Chords:Chord Output>`. In order to perform a chord, you must press all of the :ref:`input keys<Chords:Chord Input>` at the same time, within the :ref:`press time limit<GenerativeTextMenu:Press Tolerance>`. Additionally, you must release all of the keys at the same time, that is, within the :ref:`release time limit<GenerativeTextMenu:Release Tolerance>`. Once these steps are performed accurately, your CCOS device will, very quickly, type the keys pressed, backspace them, and then output the predetermined chord. 
+    A chord is a type of input that allows you to press multiple keys at a time in order to achieve a predetermined :ref:`output<Chords:Chord Output>`. In order to perform a chord, you must press all of the :ref:`input keys<Chords:Chord Input>` at the same time, within the :ref:`press time limit<GenerativeTextMenu:Press Tolerance>`. Additionally, you must release all of the keys at the same time, that is, within the :ref:`release time limit<GenerativeTextMenu:Release Tolerance>`. Once these steps are performed accurately, your CCOS device will, very quickly, type the keys pressed, backspace them, and then output the predetermined chord.
 
 We can test out your preloaded chords, of which there are 500, by :doc:`chording<Chords>` both index fingers South, towards your body. You might need to play around with the timing a bit. Just remember that you have to press both switches together, at the same time, and then release them at the same time. As mentioned before, it might take a bit of playing around with the timing, but, eventually, you should see the word "the" output onto your typing space. Congratulations! You just performed a chord!
 
 .. dropdown:: Some other chords you can try
-    
+
     Here are some other preloaded chords that you can try. You can read the section on :ref:`chord notation<Chords:Chord Notation>` for instructions on how to interpret the following chords.
         - c+b = because
         - m+b = maybe
@@ -250,11 +250,11 @@ Checking your Device’s Firmware
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You can check your device’s current firmware by following the steps
-below: 
+below:
 
-#. On a chromium based browser, such as Chrome, go to the CharaChorder `Device Manager <https://charachorder.io/config/layout/>`__ 
+#. On a chromium based browser, such as Chrome, go to the CharaChorder `Device Manager <https://charachorder.io/config/layout/>`__
 #. Click “Connect” at the bottom center of the page
-   
+
 .. _Connect Button Check Firmware:
 .. image:: /assets/images/FW-connect-button.JPG
   :width: 600
@@ -282,7 +282,7 @@ Updating the Firmware
 If you find that your device is not running the latest firmware version,
 you can follow the steps below to update your device. You can check
 which is the latest firmware release by visiting `this
-site <https://charachorder.io/ccos/m4g_s3/>`__. 
+site <https://charachorder.io/ccos/m4g_s3/>`__.
 
 .. warning::
    IMPORTANT: Before performing the below steps, please make sure that you have a :ref:`backup of your layout<Device Manager:Creating a Backup>` as well as a :ref:`backup of your chord library<Device Manager:Creating a Backup>` and a :ref:`backup of your GTM settings<Device Manager:Creating a Backup>`. The update might reset those, so it's important that you keep backup files handy. For instructions on how to restore backed up files, visit the :ref:`Backups<Device Manager:Restoring from a Backup>`    section.
@@ -296,26 +296,26 @@ The Master Forge supports over-the-air (OTA) updates. You can follow the steps b
           :width: 600
           :alt: CCOS button
     #. Out of the options at the top, select ``m4g_s3``
-       
+
         .. _Firmware Selection:
         .. image:: /assets/images/m4g-firmware-selection.JPG
           :width: 600
           :alt: The correct firmware to select
     #. You can compare the latest release (the version at the top of the list) with your device's version. Select your desired version.
     #. If you haven't done so already, Connect your device to the Manager by clicking "Connect" at the bottom of the page
-        
+
         .. _Connect Button Update Firmware:
         .. image:: /assets/images/FW-connect-button.JPG
           :width: 600
           :alt: Connect Button on Device Manager
     #. When the popup box comes up that reads “charachorder.io wants to connect to a serial port”, choose your Master Forge, then click the blue “connect” button
-     
+
         .. _Serial Port Popup Update Firmware:
         .. image:: /assets/images/SerialPort-Message.webp
           :width: 600
           :alt: Popup to select serial device
     #. Click the blue "Apply Update" button
-        
+
         .. _Apply Update Button:
         .. image:: /assets/images/DM-applyupdate-button.jpg
           :width: 600
@@ -325,11 +325,11 @@ Your device will reboot on its own and will have the new firmware on it once it 
 
 
 .. Dropdown: Only use in Emergency
-	
+
 	If, for some reason, you weren't able to complete an OTA update, you can follow the steps below to update your CCOS manually.
 
  	Doing it manually, the Master Forge must be updated one :ref:`digitizer<Master Forge:The Digitizers>` at a time.
- 		#. On a chromium based browser, such as Chrome, go to the CharaChorder `Device Manager <https://charachorder.io/ccos/>`__ 
+ 		#. On a chromium based browser, such as Chrome, go to the CharaChorder `Device Manager <https://charachorder.io/ccos/>`__
  		#. If not auto-connected, click "Connect"
 
        		   .. _Connect Button Emergency:
@@ -366,7 +366,7 @@ Your device will reboot on its own and will have the new firmware on it once it 
    				IMPORTANT: Make sure that the file you download is named exactly like this: CURRENT.UF2 . If there are any other characters in the file name, the file will not work. “CURRENT.UF2(1)” will NOT work. Additionally, the file name is case sensitive; all letters must be capitalized.
 
 
-    
+
  		#. Copy the CURRENT.UF2 file that you just downloaded and paste it into the Forge drive in your file explorer
  		#. When your computer asks you how you would like to resolve the issue of two files with the same name, select “Replace file”.
 
@@ -452,7 +452,7 @@ The default on the Master Forge :ref:`digitizers<The Digitizers>`, which we will
    General consensus amongst the community is that, while not perfect,
    the letter arrangement of the default layout is good enough that further modifications would provide very little benefit
    considering 500+ WPM have been reached in peak conditions.
-   
+
    **Most commonly only special character and number placement are changed**, for example to benefit coding.
 
    Some exceptions include optimizing for VIM bindings, though people have successfully used the default layout for VIM as well
@@ -484,12 +484,12 @@ By default, auxiliary layers are accessible by pressing and holding the "layer a
 
 .. _Toggleable Layers:
 .. dropdown:: Toggleable Layers
-   
-    If you have no interest in knowing why this works, you may skip down to the steps described below in order to enable toggleable layers.
-    CCOS devices use a "shifted' layer method that requires a press and hold of a key in order to access keys on auxiliary layers. By default, the layer access keys tell the device to go into that layer. Releasing the switch tells the device to return to the base layer, since the same "location" is mapped to the layer access button on the target layer as well. We can exploit this functionality and force the CCOS device to stay in a certain layer by simply removing the layer access key from the target layer. That way, the device doesn't know that it should return to the base layer when you release the switch. 
 
-    In order to set your device up to have toggleable layers instead of shifted layers, you'll need to head to the `Device Manager <https://charachorder.io/config/layout/>`__ and remap some keys. We'll describe here how to remap the A2 layer access key, but the same steps apply to the A3 layer. These instructions assume that you have already connected your device to the `Device Manager <https://charachorder.io/config/layout/>`__. 
-    
+    If you have no interest in knowing why this works, you may skip down to the steps described below in order to enable toggleable layers.
+    CCOS devices use a "shifted' layer method that requires a press and hold of a key in order to access keys on auxiliary layers. By default, the layer access keys tell the device to go into that layer. Releasing the switch tells the device to return to the base layer, since the same "location" is mapped to the layer access button on the target layer as well. We can exploit this functionality and force the CCOS device to stay in a certain layer by simply removing the layer access key from the target layer. That way, the device doesn't know that it should return to the base layer when you release the switch.
+
+    In order to set your device up to have toggleable layers instead of shifted layers, you'll need to head to the `Device Manager <https://charachorder.io/config/layout/>`__ and remap some keys. We'll describe here how to remap the A2 layer access key, but the same steps apply to the A3 layer. These instructions assume that you have already connected your device to the `Device Manager <https://charachorder.io/config/layout/>`__.
+
     #. Make sure that the A2 layer access key is mapped to the key of your choice on the Alpha layer (A1 layer). This is the key you will use to toggle into the A2 layer
     #. On the A2 layer, find the same location that you mapped the A2 layer access key and change that key (on the A2 layer) to ``No Key Pressed``. This change is what prevents your device from shifting back into the A1 layer
     #. On the A2 layer, choose another location and map the A2 layer access key there. This is the key that you will use to return to the Alpha layer.
@@ -525,7 +525,7 @@ A2 Layer
 The A2 layer, sometimes referred to as the “number layer”, is accessible
 with the :doc:`A2 access key<CharaChorder Keys>`. In the above :ref:`graphic<CCEnglish Layout>`, you’ll see this labeled
 as “num-shift.” In the `Device Manager <https://charachorder.io/config/layout/>`__,
-this key has the name “Numeric Layer (Left)” and “Numeric Layer (Right)”, one for each :ref:`digitizer<Master Forge:The Digitizers>`. 
+this key has the name “Numeric Layer (Left)” and “Numeric Layer (Right)”, one for each :ref:`digitizer<Master Forge:The Digitizers>`.
 
 By default, the A2 Layer is accessible by pressing and holding either
 pinky finger outwards, that is, west on the left pinky or east on the
@@ -566,36 +566,36 @@ Shift Modifier
 ^^^^^^^^^^^^^^
 
 .. dropdown:: List of shifted key actions
-        
+
         .. csv-table:: Shifted Key Actions
            :header-rows: 1
            :stub-columns: 0
            :widths: auto
 
            "Alpha key", "Shifted key"
-           "\`", "~" 
+           "\`", "~"
            "1", "\!"
            "2", "\@"
            "3", "\#"
-           "4", "\$" 
+           "4", "\$"
            "5", "\%"
            "6", "\^"
            "7", "\&"
-           "8", "\*" 
+           "8", "\*"
            "9", "\("
            "0", "\)"
            "\-", "\_"
-           "=", "\+" 
+           "=", "\+"
            "[", "\{"
            "]", "\}"
            "\\", "\|"
-           ";", ":" 
+           ";", ":"
            "\'", """"
            "\,", "\<"
            ".", ">"
            "/", "?"
-   
- 
+
+
 
 On top of the three aforementioned layers, the :doc:`Shift key<CharaChorder Keys>`, which is a :doc:`modifier<Glossary>`, can be used to access some extra keys. The Shift keypress works just like it
 would on a traditional keyboard. You can capitalize letters and access
@@ -638,7 +638,7 @@ works and how to remap your device, visit the :ref:`remapping section<Device Man
 Master Forge Configurations
 ***************************
 
-When the Master Forge was `unveiled <https://youtu.be/fux9gU3M25E?si=u4KW7OaUUUNINfKD&t=1025>`__ in Novemeber of 2023, CharaChorder began taking pre-orders offering everyone the same bundle. In September of 2024, CharaChorder ran a `Kickstarter <https://www.kickstarter.com/projects/charachorder/the-master-forge-a-keyboard-built-for-you>`__ campaign for the Master Forge for 5 weeks, offering three different tiers, each with a different configuration. After the Kickstarter campaign finished, the Master Forge went on back-order sale on the `Forge website <https://forgekeyboard.com>`__. The following section identifies what each of these 5 bundles included. 
+When the Master Forge was `unveiled <https://youtu.be/fux9gU3M25E?si=u4KW7OaUUUNINfKD&t=1025>`__ in Novemeber of 2023, CharaChorder began taking pre-orders offering everyone the same bundle. In September of 2024, CharaChorder ran a `Kickstarter <https://www.kickstarter.com/projects/charachorder/the-master-forge-a-keyboard-built-for-you>`__ campaign for the Master Forge for 5 weeks, offering three different tiers, each with a different configuration. After the Kickstarter campaign finished, the Master Forge went on back-order sale on the `Forge website <https://forgekeyboard.com>`__. The following section identifies what each of these 5 bundles included.
 
 Forge Website Pre-Orders
 ------------------------
@@ -664,7 +664,7 @@ The Master Forge was announced at CharaChorder's annual `ChorderCon in 2023 <htt
 Kickstarter Orders
 ------------------
 
-The Master Forge Kickstarter campaign launched on August 27 of 2024 and closed on October 7 of 2024. The bundles offered on Kickstarter can be separated into three: Basic, Premium, and Super.  
+The Master Forge Kickstarter campaign launched on August 27 of 2024 and closed on October 7 of 2024. The bundles offered on Kickstarter can be separated into three: Basic, Premium, and Super.
 
 Basic
 ~~~~~

--- a/docs/SerialAPI.rst
+++ b/docs/SerialAPI.rst
@@ -9,7 +9,7 @@ The Serial API allows users and developers to interact with their CCOS powered d
   Running some simple commands on serialterminal.com
 
 .. warning::
-   Parameter and keymaps changes, when **committed**, will degrade the flash chip over time (generally a minimum of 10,000 to 25,000 commits are expected to be stable). If you use the commands below, keep in mind that if you accidentally write a program that unnecessarily commits parameters to your device you can wear it out prematurely.  If you plan to programmatically change layouts, for example, you shouldn’t commit the changes unless you need them to persist after power loss. 
+   Parameter and keymaps changes, when **committed**, will degrade the flash chip over time (generally a minimum of 10,000 to 25,000 commits are expected to be stable). If you use the commands below, keep in mind that if you accidentally write a program that unnecessarily commits parameters to your device you can wear it out prematurely.  If you plan to programmatically change layouts, for example, you shouldn’t commit the changes unless you need them to persist after power loss.
 
    Chords are stored on external flash and have a minimum of 100,000 commits before any degradation could be expected; however, we have a custom wear leveling algorithm that targets specific sectors so this should extend much farther and is less of a concern.
 
@@ -22,7 +22,7 @@ The Serial API allows users and developers to interact with their CCOS powered d
 Commands Overview
 -----------------
 
-Commands are all caps ASCII characters. The return is always one line and includes the command in the return line along with some of the relevant input arguments as well. This makes it more restful and stateless as compared to previous versions of the Serial API. 
+Commands are all caps ASCII characters. The return is always one line and includes the command in the return line along with some of the relevant input arguments as well. This makes it more restful and stateless as compared to previous versions of the Serial API.
 
 .. csv-table::
    :header: "Command", "Description"
@@ -38,7 +38,7 @@ Commands are all caps ASCII characters. The return is always one line and includ
 
 Commands
 --------
-This section covers the various commands, what they expect, what they return, and has examples of how to use them. 
+This section covers the various commands, what they expect, what they return, and has examples of how to use them.
 
 CMD
 ~~~
@@ -52,7 +52,7 @@ The `CMD` command lists out all of the commands in the Serial API. All of the co
    "OUTPUT", "0", "Command", "Chars", "CMD"
    "OUTPUT", "1", "Command List", "Chars", "CMD,ID,VERSION,CML,VAR,RST,RAM,SIM","Comma delimited"
 
-Example(s): 
+Example(s):
 
 .. code-block:: none
 
@@ -72,7 +72,7 @@ attached to the computer.
    "OUTPUT","0","Command","Chars","ID",""
    "OUTPUT","1","Company","Chars","CHARACHORDER",""
    "OUTPUT","2","Device","Chars","ONE","ONE, LITE, ENGINE, or X"
-   "OUTPUT","3","Chipset","Chars","M0","M0 or S2" 
+   "OUTPUT","3","Chipset","Chars","M0","M0 or S2"
 
 Example(s):
 
@@ -94,7 +94,7 @@ The `VERSION` command returns the current version of the CCOS firmware.
    "OUTPUT","0","Command","Chars","VERSION",""
    "OUTPUT","1","Command List","Chars","1.1.1","Period delimited of MAJOR.MINOR.BUILD"
 
-Example(s): 
+Example(s):
 
 .. code-block:: none
 
@@ -401,7 +401,7 @@ CMD_VAR_SET_KEYMAP
 
 .. csv-table::
    :header: "I/O","Index","Name","Type","Example","Notes"
-   
+
    "INPUT","0","Command","Chars","VAR",""
    "INPUT","1","SubCommand","Hexadecimal VAR Code","B4","Set keymap parameter value"
    "INPUT","2","Keymap","Hexadecimal Keymap Code","A1",""
@@ -488,7 +488,7 @@ The `SIM` command provides a way to inject a chord or key states to be processed
    "OUTPUT","3","Data Out","Hexadecimal CCActionCodes List","6361727065206469656D","`carpe diem`"
 
 
-Example(s): 
+Example(s):
 
 .. code-block:: none
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,11 +10,11 @@ Welcome to the wonderful world of CharaChorder! If you're here, you are likely s
 
 .. _ChangingLanguage:
 
-Before even unboxing your CharaChorder, we encourage you to set up your computer with an English Keyboard Language. We recommend ``US English`` for the best results. If you would like to read instructions on how to change your computer Keyboard Language, feel free to follow the applicable external link for `Windows <https://support.microsoft.com/en-us/office/switch-between-languages-using-the-language-bar-1c2242c0-fe15-4bc3-99bc-535de6f4f258>`__, `Mac <https://support.apple.com/guide/mac-help/write-in-another-language-on-mac-mchlp1406/mac>`__ or `Linux (Ubuntu) <https://help.ubuntu.com/stable/ubuntu-help/keyboard-layouts.html.en>`__. 
+Before even unboxing your CharaChorder, we encourage you to set up your computer with an English Keyboard Language. We recommend ``US English`` for the best results. If you would like to read instructions on how to change your computer Keyboard Language, feel free to follow the applicable external link for `Windows <https://support.microsoft.com/en-us/office/switch-between-languages-using-the-language-bar-1c2242c0-fe15-4bc3-99bc-535de6f4f258>`__, `Mac <https://support.apple.com/guide/mac-help/write-in-another-language-on-mac-mchlp1406/mac>`__ or `Linux (Ubuntu) <https://help.ubuntu.com/stable/ubuntu-help/keyboard-layouts.html.en>`__.
 
 This guide has been designed to link itself to other sections of itself for quick reference and ease of access. Anything that is highlighted in blue or purple is clickable and will take you to another portion of the guide. Please note that this guide is currently a work in progress and is not final in any way. As such, many of the pages that are linked might be empty. We thank you for your patience as we work arduously to release more pages.
 
-If you would like to submit a correction to something you've read in this guide, or if you have suggestions for the guide, please email alan@charachorder.com. 
+If you would like to submit a correction to something you've read in this guide, or if you have suggestions for the guide, please email alan@charachorder.com.
 
 
 Table of Contents
@@ -22,7 +22,7 @@ Table of Contents
 
 .. toctree::
    :maxdepth: 2
-   
+
    Master Forge.rst
    CharaChorder One.rst
    CharaChorder Two.rst


### PR DESCRIPTION
Trimming trailing whitespace in all files now. Will make future changes easier. Otherwise, the first time a file with trailing whitespace is changed, with an editor that automatically trims trailing whitespace, then it will look like changes where made to unrelated lines (trailing whitespace removed).