### PR TITLE
Device Manager, Fix, page auto scroll, etc

### DIFF
--- a/docs/Device Manager.rst
+++ b/docs/Device Manager.rst
@@ -646,15 +646,4 @@ You can see the action codes below, or view them externally `here. <https://docs
 
 .. raw:: html
 
-    <iframe src="https://docs.google.com/spreadsheets/d/1--T9bXshCIC-OVly-CY3rK87fgb7AHgJl3IySh7cmHc/edit#gid=0" width="600" height="600"></iframe>
-
-
-
-
-
-
-
-
-
-
-
+	<iframe src="https://docs.google.com/spreadsheets/d/1--T9bXshCIC-OVly-CY3rK87fgb7AHgJl3IySh7cmHc/preview" width="100%" height="600"></iframe>


### PR DESCRIPTION
- Embedding a google sheet in edit mode caused the whole page to scroll to the middle. 
- And ctrl + f searched the embedded sheet. Until the main page is clicked to give it focus.