### PR TITLE
Unify indentation to 4 spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ If you want to link to a specific anchor:
 
 ```
 .. csv-table::
-:header: "Device", "Default", "Min. Value", "Max. Value", "Increments"
+    :header: "Device", "Default", "Min. Value", "Max. Value", "Increments"
 
     "CharaChorder One", ""
     "CharaChorder Lite", ""
@@ -77,6 +77,6 @@ If you want to link to a specific anchor:
 
 ```
 .. image:: /assets/images/PATH-TO-IMAGE.png
-  :width: 1200
-  :alt: Alt text for screen readers
+    :width: 1200
+    :alt: Alt text for screen readers
 ```

--- a/docs/Beta Releases.rst
+++ b/docs/Beta Releases.rst
@@ -2,7 +2,7 @@ Beta Releases
 =============
 
 .. contents::
-	:local:
+    :local:
 
 2.2.0-beta
 **********
@@ -38,57 +38,57 @@ With Profile B set up for gaming, the key bindings could look like this:
 
 Layer B1::
 
-	Left Ring
-	   any
-	any   any
-	   B3
+    Left Ring
+       any
+    any   any
+       B3
 
-	Left Middle
-	   any
-	any   any
-	   B2
+    Left Middle
+       any
+    any   any
+       B2
 
-	Left Thumb 1
-	   w
-	a     d
-	   s
+    Left Thumb 1
+       w
+    a     d
+       s
 
 
 Layer B2::
 
-	Left Middle
-	   any
-	any   any
-	   B2
+    Left Middle
+       any
+    any   any
+       B2
 
-	Left Thumb 1
-	   s
-	d     a
-	   w
+    Left Thumb 1
+       s
+    d     a
+       w
 
 Layer B3::
 
-	Left Ring
-	     any
-	any       any
-	     B3
+    Left Ring
+         any
+    any       any
+         B3
 
-	Left Thumb 1
-	     BLANK
-	BLANK     BLANK
-	     BLANK
+    Left Thumb 1
+         BLANK
+    BLANK     BLANK
+         BLANK
 
 We walk forward by holding Left Thumb 1 North (``w``).
 
 Reverse direction:
 
-	* We reverse direction temporarily by also holding Left Middle South (Layer B2), because it causes a repress of Left Thumb 1 North, which is now bound to ``s``.
-	* We start walking forward again by releasing Left Middle South (B2), it represses Left Thumb 1 North (``w``).
+* We reverse direction temporarily by also holding Left Middle South (Layer B2), because it causes a repress of Left Thumb 1 North, which is now bound to ``s``.
+* We start walking forward again by releasing Left Middle South (B2), it represses Left Thumb 1 North (``w``).
 
 Stop:
 
-	* We stop temporarily by holding Left Ring South (Layer B3), it represses Left Thumb 1 North, which isn't bound to anything.
-	* We start walking forward again by releasing Left Ring South (B3), it represses Left Thumb 1 North (``w``).
+* We stop temporarily by holding Left Ring South (Layer B3), it represses Left Thumb 1 North, which isn't bound to anything.
+* We start walking forward again by releasing Left Ring South (B3), it represses Left Thumb 1 North (``w``).
 
 Hyperspace
 ~~~~~~~~~~
@@ -99,41 +99,41 @@ The CAPTURE action makes it possible to replace the space after a chord with ano
 
 For this to work, we need to create at least two chords:
 
-1. One chord that has a space between two CAPTURE actions:
+* One chord that has a space between two CAPTURE actions:
 
-	.. code-block::
+    .. code-block::
 
-		CAPTURE CAPTURE
+        CAPTURE CAPTURE
 
-	It restores the default behavior of adding a space after each chord:
+    It restores the default behavior of adding a space after each chord:
 
-	.. code-block::
+    .. code-block::
 
-		the on us
+        the on us
 
-2. Another chord that has a character between the CAPTURE actions, to replace the space:
+* Another chord that has a character between the CAPTURE actions, to replace the space:
 
-	.. code-block::
+    .. code-block::
 
-		CAPTURE-CAPTURE
+        CAPTURE-CAPTURE
 
-	This results in:
+    This results in:
 
-	.. code-block::
+    .. code-block::
 
-		the-on-us-
+        the-on-us-
 
-3. Or:
+* Or:
 
-	.. code-block::
+    .. code-block::
 
-		CAPTURE_CAPTURE
+        CAPTURE_CAPTURE
 
-	Which results in:
+    Which results in:
 
-	.. code-block::
+    .. code-block::
 
-		the_on_us_
+        the_on_us_
 
 Prepend concatenation style
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -145,8 +145,8 @@ Vim mode
 
 .. note::
 
-	Mac users. Set the Operating System setting to: Mac
-	https://charachorder.io/config/settings/#misc
+    Mac users. Set the Operating System setting to: Mac
+    https://charachorder.io/config/settings/#misc
 
 Adds universal VIM motion emulation through the VIM action. This mode makes use of standard shortcuts like CTRL (or ⌘ on Mac) + RIGHT ARROW to emulate VIM motions in a best-effort way in any textbox. While not as powerful as native VIM or even just a VIM plugin, you don't always have the option to use either of them, so this is a way to carry around your VIM muscle memory to nearly every textbox you encounter.
 
@@ -228,13 +228,13 @@ chord, period, character, space, chord
 
 Before::
 
-	the. t The
+    the. t The
 
 The last chord became capitalized even though it wasn't the first character or chord after the period.
 
 Now::
 
-	the. t the
+    the. t the
 
 The last chord's capitalization was interrupted by the chentry.
 

--- a/docs/CCOS.rst
+++ b/docs/CCOS.rst
@@ -28,19 +28,19 @@ some things you can expect to experience moving forward as we peel back the
 layers and start to unlock the full potential of CCOS with future updates:
 
 - :ref:`Compound Chording<Chords:Compound Chords>`, the ability for any chord combination in any
-  layout to be compounded with up to twelve other chords, with each compounding
-  layer being tied to its own unique output.
+    layout to be compounded with up to twelve other chords, with each compounding
+    layer being tied to its own unique output.
 - An interface for programming advanced keyboard/mouse macros which can be
-  assigned to either individual switches or chord outputs
+    assigned to either individual switches or chord outputs
 - Soon, the only limitation for chord length will be the memory on your
-  device due to the new CCOS architecture's capability to link together an
-  infinite number of memory locations to a single chord output.
+    device due to the new CCOS architecture's capability to link together an
+    infinite number of memory locations to a single chord output.
 - Increased independence of CharaChorder devices, including the ability of
-  future generation devices to operate in the complete absence of an external computer.
+    future generation devices to operate in the complete absence of an external computer.
 - More sophisticated mouse and cursor control, and future generation devices
-  which function as a total mouse replacement, even for (and especially for)
-  activities which require high precision/high speed cursor control such as
-  gaming, modeling, & design.
+    which function as a total mouse replacement, even for (and especially for)
+    activities which require high precision/high speed cursor control such as
+    gaming, modeling, & design.
 
 CCOS was not designed for any one product, or even for a portfolio of products.
 In alignment with our :doc:`mission<CharaChorder's Mission>` to get the whole

--- a/docs/CharaChorder Engine.rst
+++ b/docs/CharaChorder Engine.rst
@@ -6,8 +6,8 @@ below to navigate to the topics that you find most relevant.
 
 .. _CCE:
 .. image:: /assets/images/CharaChorderEngine.jpg
-  :width: 1200
-  :alt: CharaChorder Engine
+    :width: 1200
+    :alt: CharaChorder Engine
 
 CharaChorder Engine is a multichip module that enables you to build your own
 CCOS powered text entry device. If you are interested in learning how to utilize
@@ -15,15 +15,15 @@ CharaChorder Engine, please visit the `CharaChorder Engine Discord channel <http
 and ping Riley Keen or Matt Swarts.
 
 .. contents:: Table of Contents of this Page
-   :local:
+    :local:
 
 Pinout Diagram
 **************
 
 .. _CCEPinout:
 .. image:: /assets/cce/pinout.png
-  :width: 1200
-  :alt: CharaChorder Engine pinout table
+    :width: 1200
+    :alt: CharaChorder Engine pinout table
 
 Design
 ******

--- a/docs/CharaChorder One.rst
+++ b/docs/CharaChorder One.rst
@@ -6,11 +6,11 @@ below to navigate to the topics that you find most relevant.
 
 .. _CC1:
 .. image:: /assets/images/CC1.png
-  :width: 1200
-  :alt: CharaChorder One
+    :width: 1200
+    :alt: CharaChorder One
 
 .. contents:: Table of Contents of this Page
-   :local:
+    :local:
 
 Out of the Box
 **************
@@ -20,8 +20,8 @@ Parts
 
 .. _CC1 Schematic:
 .. image:: /assets/images/CC1Scheme.png
-  :width: 1200
-  :alt: CC1 Scheme
+    :width: 1200
+    :alt: CC1 Scheme
 
 When you first receive your CharaChorder One, it will come in a black
 box with the CharaChorder logo on the outside. Once you open the box,
@@ -31,8 +31,8 @@ some functions that the CharaChorder One has.
 
 .. _CC1 Case:
 .. image:: /assets/images/CC1case.png
-  :width: 1200
-  :alt: CharaChorder One Travel Case
+    :width: 1200
+    :alt: CharaChorder One Travel Case
 
 Once you unzip the travel case, you’ll meet your shiny, new CharaChorder
 One. The CharaChorder One consists of two halves with 9, 5-way switches
@@ -84,13 +84,13 @@ there are two black switches off the “home-row” which can be accessed by
 the ring and middle fingers.
 
 .. note::
-   **IMPORTANT**: In this manual, we will refer to switches in the
-   following way, starting from the pinky finger and working inwards:
-   pinky, ring, middle, index, thumb 1, thumb 2, thumb 3. The black
-   switches below the “home-row” will be referred to as the arrow and
-   mouse switches, where the switch further to the left on the left half
-   of the CharaChorder is the mouse switch. Symmetrically, the mouse
-   switch is the switch furthest to the right on the right half.
+    **IMPORTANT**: In this manual, we will refer to switches in the
+    following way, starting from the pinky finger and working inwards:
+    pinky, ring, middle, index, thumb 1, thumb 2, thumb 3. The black
+    switches below the “home-row” will be referred to as the arrow and
+    mouse switches, where the switch further to the left on the left half
+    of the CharaChorder is the mouse switch. Symmetrically, the mouse
+    switch is the switch furthest to the right on the right half.
 
 Each switch has five press-able directions. Throughout this guide, we
 will use cardinal directions to refer to the directions in which each
@@ -184,10 +184,10 @@ Updating your Device
 --------------------
 
 .. warning::
-   IMPORTANT: If your device shipped from our warehouse before 2023,
-   it’s possible that it is running an obsolete firmware. You can read
-   instructions on how to upgrade your device to our new CCOS :ref:`here<CCOS:Upgrade to CCOS>`. If your device is not running    :doc:`CCOS<CCOS>`, you will be unable to follow the
-   steps below to update your device.
+    IMPORTANT: If your device shipped from our warehouse before 2023,
+    it’s possible that it is running an obsolete firmware. You can read
+    instructions on how to upgrade your device to our new CCOS :ref:`here<CCOS:Upgrade to CCOS>`. If your device is not running    :doc:`CCOS<CCOS>`, you will be unable to follow the
+    steps below to update your device.
 
 Checking your Device’s Firmware
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -199,19 +199,19 @@ below:
 #. Click “Connect” at the bottom middle of the page
 #. When the popup box comes up that reads “charachorder.io wants to connect to a serial port”, choose your CharaChorder device, then click the “connect” button
 
-   .. _Serial Port Popup Check Firmware:
-   .. image:: /assets/images/SerialPort-Message-CC1.webp
-      :width: 435
-      :alt: Popup to select serial device
+    .. _Serial Port Popup Check Firmware:
+    .. image:: /assets/images/SerialPort-Message-CC1.webp
+        :width: 435
+        :alt: Popup to select serial device
 
 After following the above steps, you can find your
 firmware version in the bottom left of your screen. It will read
 something like this: ``CCOS 2.1.0``
 
-   .. _Bottom Bar Check Firmware:
-   .. image:: /assets/images/DM-Bottom-Bar-CC1-M0.webp
-      :width: 1200
-      :alt: Checking the firmware on Device Manager
+    .. _Bottom Bar Check Firmware:
+    .. image:: /assets/images/DM-Bottom-Bar-CC1-M0.webp
+        :width: 1200
+        :alt: Checking the firmware on Device Manager
 
 Updating the Firmware
 ~~~~~~~~~~~~~~~~~~~~~
@@ -222,23 +222,23 @@ which is the latest firmware release by visiting `this
 site <https://charachorder.io/ccos/>`__.
 
 .. warning::
-   IMPORTANT: Before performing the below steps, please make sure that you have a :ref:`backup of your layout, chord library, and settings<Device Manager:Creating a Backup>`. The update might reset those, so it's important that you keep backup files handy. For instructions on how to restore backed up files, visit the :ref:`Backups<Device Manager:Restoring from a Backup>` section.
+    IMPORTANT: Before performing the below steps, please make sure that you have a :ref:`backup of your layout, chord library, and settings<Device Manager:Creating a Backup>`. The update might reset those, so it's important that you keep backup files handy. For instructions on how to restore backed up files, visit the :ref:`Backups<Device Manager:Restoring from a Backup>` section.
 
 #. On a chromium based browser, such as Chrome, go to the CharaChorder `Device Manager <https://charachorder.io/config/layout/>`__
 #. If not auto-connected, click “Connect”
 #. When the popup box comes up that reads “charachorder.io wants to connect to a serial port”, choose your CharaChorder device, then click the “connect” button
 
-   .. _Serial Port Popup Update Firmware:
-   .. image:: /assets/images/SerialPort-Message-CC1.webp
-      :width: 435
-      :alt: Popup to select serial device
+    .. _Serial Port Popup Update Firmware:
+    .. image:: /assets/images/SerialPort-Message-CC1.webp
+        :width: 435
+        :alt: Popup to select serial device
 
 #. Click on the CCOS version on the bottom left of the page
 
-   .. _Bottom Bar Update Firmware:
-   .. image:: /assets/images/DM-Bottom-Bar-CC1-M0.webp
-      :width: 1200
-      :alt: Checking the firmware on Device Manager
+    .. _Bottom Bar Update Firmware:
+    .. image:: /assets/images/DM-Bottom-Bar-CC1-M0.webp
+        :width: 1200
+        :alt: Checking the firmware on Device Manager
 
 #. You will see a list of available versions along with their release date. Click on the one you want.
 #. Follow the steps on screen to update your device.
@@ -286,20 +286,20 @@ Learning the Layout
 The default CharaChorder layout, which we will refer to as the CC English layout, has been designed to favor bigrams and trigrams commonly used in the English language while making the letters accessible for a logical choice of :doc:`lexical chords<Chords>`. You can find the quick reference guide for the layout below, and :ref:`read about how the layout was designed, here <Layout:Design of the layout>`.
 
 .. note::
-   General consensus amongst the community is that, while not perfect,
-   the letter arrangement of the default layout is good enough that further modifications would provide very little benefit
-   considering 500+ WPM have been reached in peak conditions.
+    General consensus amongst the community is that, while not perfect,
+    the letter arrangement of the default layout is good enough that further modifications would provide very little benefit
+    considering 500+ WPM have been reached in peak conditions.
 
-   **Most commonly only special character and number placement is changed**, for example to benefit coding.
+    **Most commonly only special character and number placement is changed**, for example to benefit coding.
 
-   Some exceptions include optimizing for VIM bindings, though people have successfully used the default layout for VIM as well
-   and benefits of such modifications are debatable.
+    Some exceptions include optimizing for VIM bindings, though people have successfully used the default layout for VIM as well
+    and benefits of such modifications are debatable.
 
 
 .. _CCEnglish Layout:
 .. image:: /assets/images/CCEnglish.png
-  :width: 1200
-  :alt: CC English Layout
+    :width: 1200
+    :alt: CC English Layout
 
 Layers
 ~~~~~~
@@ -347,9 +347,9 @@ need to :doc:`chord<Chords>` the keys together; it’s only required that the
 A2 Layer access key is pressed while the target key is pressed.
 
 .. note::
-   EXAMPLE: On the CC English layout, you can access the number
-   ``4`` by pressing and holding the right pinky to the east and the
-   left middle finger to the east.
+    EXAMPLE: On the CC English layout, you can access the number
+    ``4`` by pressing and holding the right pinky to the east and the
+    left middle finger to the east.
 
 A3 Layer
 ^^^^^^^^
@@ -371,8 +371,8 @@ together; it’s only required that the A3 layer access key is pressed
 while the target key is pressed.
 
 .. note::
-   EXAMPLE: On the CC English layout, you can access the F1 key by
-   pressing and holding either pinky down, into the device, and adding the letter ``a`` or ``r`` (location of number 1 on the default layout) to it.
+    EXAMPLE: On the CC English layout, you can access the F1 key by
+    pressing and holding either pinky down, into the device, and adding the letter ``a`` or ``r`` (location of number 1 on the default layout) to it.
 
 Shift Modifier
 ^^^^^^^^^^^^^^
@@ -398,12 +398,12 @@ holding the Shift key along with the target key. You do not need to
 key is pressed while the target key is pressed.
 
 .. note::
-   EXAMPLE: On the CC English layout, you can access the capital
-   ``A`` by pressing and holding the left pinky to the east and the
-   right index finger to the west.
+    EXAMPLE: On the CC English layout, you can access the capital
+    ``A`` by pressing and holding the left pinky to the east and the
+    right index finger to the west.
 
-   On the CC English layout, you can access the ``@`` symbol by pressing
-   and holding both pinkies to the east and the left index south.
+    On the CC English layout, you can access the ``@`` symbol by pressing
+    and holding both pinkies to the east and the left index south.
 
 Configurability
 ~~~~~~~~~~~~~~~
@@ -427,5 +427,5 @@ training website; https://www.iq-eq.io/#/
 
 .. _Dot I/O:
 .. image:: /assets/images/DOTIO.png
-  :width: 1200
-  :alt: Practicing on DOT I/O
+    :width: 1200
+    :alt: Practicing on DOT I/O

--- a/docs/CharaChorder Two.rst
+++ b/docs/CharaChorder Two.rst
@@ -6,11 +6,11 @@ below to navigate to the topics that you find most relevant.
 
 .. _CC2:
 .. image:: /assets/images/CC2.webp
-  :width: 1200
-  :alt: CharaChorder CC2
+    :width: 1200
+    :alt: CharaChorder CC2
 
 .. contents:: Table of Contents of this Page
-   :local:
+    :local:
 
 Out of the Box
 **************
@@ -26,8 +26,8 @@ some functions that the CC2 has.
 
 .. _CC2 Case:
 .. image:: /assets/images/CC1case.png
-  :width: 1200
-  :alt: CC2 Travel Case
+    :width: 1200
+    :alt: CC2 Travel Case
 
 Once you unzip the travel case, you’ll meet your shiny, new CharaChorder
 Two. The CC2 consists of two halves, each one having nine 3D switches, held together by a machined aluminum center bar.
@@ -68,13 +68,13 @@ there are two switches off the “home-row” which can be accessed by
 the ring and middle fingers.
 
 .. note::
-   **IMPORTANT**: In this manual, we will refer to switches in the
-   following way, starting from the pinky finger and working inwards:
-   pinky, ring, middle, index, thumb 1, thumb 2, thumb 3. The
-   switches below the “home-row” will be referred to as the arrow and
-   mouse switches, where the switch further to the left on the left half
-   of the CC2 is the mouse switch. Symmetrically, the mouse
-   switch is the switch furthest to the right on the right half.
+    **IMPORTANT**: In this manual, we will refer to switches in the
+    following way, starting from the pinky finger and working inwards:
+    pinky, ring, middle, index, thumb 1, thumb 2, thumb 3. The
+    switches below the “home-row” will be referred to as the arrow and
+    mouse switches, where the switch further to the left on the left half
+    of the CC2 is the mouse switch. Symmetrically, the mouse
+    switch is the switch furthest to the right on the right half.
 
 Each switch has five press-able directions. Throughout this guide, we
 will use cardinal directions to refer to the directions in which each
@@ -172,19 +172,19 @@ below:
 #. Click “Connect” at the bottom middle of the page
 #. When the popup box comes up that reads “charachorder.io wants to connect to a serial port”, choose your CharaChorder device, then click the “connect” button
 
-   .. _Serial Port Popup Check Firmware:
-   .. image:: /assets/images/SerialPort-Message-CC2.webp
-      :width: 435
-      :alt: Popup to select serial device
+    .. _Serial Port Popup Check Firmware:
+    .. image:: /assets/images/SerialPort-Message-CC2.webp
+        :width: 435
+        :alt: Popup to select serial device
 
 After following the above steps, you can find your
 firmware version in the bottom left of your screen. It will read
 something like this: ``CCOS 2.1.0``
 
-   .. _Bottom Bar Check Firmware:
-   .. image:: /assets/images/DM-Bottom-Bar-CC2-S3.webp
-      :width: 1200
-      :alt: Checking the firmware on Device Manager
+    .. _Bottom Bar Check Firmware:
+    .. image:: /assets/images/DM-Bottom-Bar-CC2-S3.webp
+        :width: 1200
+        :alt: Checking the firmware on Device Manager
 
 Updating the Firmware
 ~~~~~~~~~~~~~~~~~~~~~
@@ -195,23 +195,23 @@ which is the latest firmware release by visiting `this
 site <https://charachorder.io/ccos/>`__.
 
 .. warning::
-   IMPORTANT: Before performing the below steps, please make sure that you have a :ref:`backup of your layout, chord library, and settings<Device Manager:Creating a Backup>`. The update might reset those, so it's important that you keep backup files handy. For instructions on how to restore backed up files, visit the :ref:`Backups<Device Manager:Restoring from a Backup>` section.
+    IMPORTANT: Before performing the below steps, please make sure that you have a :ref:`backup of your layout, chord library, and settings<Device Manager:Creating a Backup>`. The update might reset those, so it's important that you keep backup files handy. For instructions on how to restore backed up files, visit the :ref:`Backups<Device Manager:Restoring from a Backup>` section.
 
 #. On a chromium based browser, such as Chrome, go to the CharaChorder `Device Manager <https://charachorder.io/config/layout/>`__
 #. If not auto-connected, click “Connect”
 #. When the popup box comes up that reads “charachorder.io wants to connect to a serial port”, choose your CharaChorder device, then click the “connect” button
 
-   .. _Serial Port Popup Update Firmware:
-   .. image:: /assets/images/SerialPort-Message-CC2.webp
-      :width: 435
-      :alt: Popup to select serial device
+    .. _Serial Port Popup Update Firmware:
+    .. image:: /assets/images/SerialPort-Message-CC2.webp
+        :width: 435
+        :alt: Popup to select serial device
 
 #. Click on the CCOS version on the bottom left of the page
 
-   .. _Bottom Bar Update Firmware:
-   .. image:: /assets/images/DM-Bottom-Bar-CC2-S3.webp
-      :width: 1200
-      :alt: Checking the firmware on Device Manager
+    .. _Bottom Bar Update Firmware:
+    .. image:: /assets/images/DM-Bottom-Bar-CC2-S3.webp
+        :width: 1200
+        :alt: Checking the firmware on Device Manager
 
 #. You will see a list of available versions along with their release date. Click on the one you want.
 #. Click "Apply Update"
@@ -259,20 +259,20 @@ Learning the Layout
 The default CharaChorder layout, which we will refer to as the CC English layout, has been designed to favor bigrams and trigrams commonly used in the English language while making the letters accessible for a logical choice of :doc:`lexical chords<Chords>`. You can find the quick reference guide for the layout below, and :ref:`read about how the layout was designed, here <Layout:Design of the layout>`.
 
 .. note::
-   General consensus amongst the community is that, while not perfect,
-   the letter arrangement of the default layout is good enough that further modifications would provide very little benefit
-   considering 500+ WPM have been reached in peak conditions.
+    General consensus amongst the community is that, while not perfect,
+    the letter arrangement of the default layout is good enough that further modifications would provide very little benefit
+    considering 500+ WPM have been reached in peak conditions.
 
-   **Most commonly only special character and number placement is changed**, for example to benefit coding.
+    **Most commonly only special character and number placement is changed**, for example to benefit coding.
 
-   Some exceptions include optimizing for VIM bindings, though people have successfully used the default layout for VIM as well
-   and benefits of such modifications are debatable.
+    Some exceptions include optimizing for VIM bindings, though people have successfully used the default layout for VIM as well
+    and benefits of such modifications are debatable.
 
 
 .. _CCEnglish Layout:
 .. image:: /assets/images/CCEnglish2.png
-  :width: 1200
-  :alt: CC English Layout
+    :width: 1200
+    :alt: CC English Layout
 
 Layers
 ~~~~~~
@@ -320,9 +320,9 @@ need to :doc:`chord<Chords>` the keys together; it’s only required that the
 A2 Layer access key is pressed while the target key is pressed.
 
 .. note::
-   EXAMPLE: On the CC English layout, you can access the number
-   ``4`` by pressing and holding the right pinky to the east and the
-   left middle finger to the east.
+    EXAMPLE: On the CC English layout, you can access the number
+    ``4`` by pressing and holding the right pinky to the east and the
+    left middle finger to the east.
 
 A3 Layer
 ^^^^^^^^
@@ -344,8 +344,8 @@ together; it’s only required that the A3 layer access key is pressed
 while the target key is pressed.
 
 .. note::
-   EXAMPLE: On the CC English layout, you can access the F1 key by
-   pressing and holding either pinky down, into the device, and adding the letter ``a`` or ``r`` (location of number 1 on the default layout) to it.
+    EXAMPLE: On the CC English layout, you can access the F1 key by
+    pressing and holding either pinky down, into the device, and adding the letter ``a`` or ``r`` (location of number 1 on the default layout) to it.
 
 Shift Modifier
 ^^^^^^^^^^^^^^
@@ -371,12 +371,12 @@ holding the Shift key along with the target key. You do not need to
 key is pressed while the target key is pressed.
 
 .. note::
-   EXAMPLE: On the CC English layout, you can access the capital
-   ``A`` by pressing and holding the left pinky to the east and the
-   right index finger to the west.
+    EXAMPLE: On the CC English layout, you can access the capital
+    ``A`` by pressing and holding the left pinky to the east and the
+    right index finger to the west.
 
-   On the CC English layout, you can access the ``@`` symbol by pressing
-   and holding both pinkies to the east and the left index south.
+    On the CC English layout, you can access the ``@`` symbol by pressing
+    and holding both pinkies to the east and the left index south.
 
 Configurability
 ~~~~~~~~~~~~~~~
@@ -400,5 +400,5 @@ training website; https://www.iq-eq.io/#/
 
 .. _Dot I/O:
 .. image:: /assets/images/DOTIO.png
-  :width: 1200
-  :alt: Practicing on DOT I/O
+    :width: 1200
+    :alt: Practicing on DOT I/O

--- a/docs/CharaChorder X.rst
+++ b/docs/CharaChorder X.rst
@@ -5,8 +5,8 @@ Welcome to the Official CharaChorder X guide.
 
 .. _CCX:
 .. image:: /assets/images/CCX.png
-  :width: 1200
-  :alt: CharaChorder X
+    :width: 1200
+    :alt: CharaChorder X
 
 The CharaChorder X is a plug-and-play device that serves as a middle-man between your keyboard and your computer. It allows any keyboard to have :doc:`chording<Chords>` capabilities. Essentially, the CharaChorder X is a supersuit for your keyboard that will give it the power of :doc:`chording<Chords>`.
 
@@ -15,7 +15,7 @@ What is :doc:`chording<Chords>`? Put simply, :doc:`chording<Chords>` is the acti
 Although the CharaChorder X is a very powerful device, it is limited by the keyboard that you use it with. One example of this is that :doc:`chording<Chords>` relies on your keyboard's :doc:`rollover<Glossary>` limits. A keyboard with 3-key rollover (3KRO) will not be able to make use of :doc:`chords<Chords>` that use more than 3 keys in their :doc:`input<Chords>`. We recommend using a keyboard with N-key rollover (NKRO) for best results. Feel free to choose from the list below to read the topics that you find relevant.
 
 .. contents::
-   :local:
+    :local:
 
 Out of the Box
 **************
@@ -30,8 +30,8 @@ You will also find an insert that gives instructions on how to connect the Chara
 
 .. _CCX in the box:
 .. image:: /assets/images/CCXinBox.png
-  :width: 1200
-  :alt: CharaChorder X in its Box
+    :width: 1200
+    :alt: CharaChorder X in its Box
 
 
 The Body
@@ -40,21 +40,21 @@ The Body
 The CharaChorder X is a single piece comprised of a circuit board which is enclosed in an injection molded plastic shell. It has a single female USB-A port, and a single male USB-A connector. You can find the dimensions of the CharaChorder X in the table below.
 
 .. list-table:: CharaChorder X Dimensions
-   :widths: 25 25 25 25
-   :header-rows: 1
+    :widths: 25 25 25 25
+    :header-rows: 1
 
-   * -
-     - Length
-     - Width
-     - Height
-   * - **Shell**
-     - 59 mm (5/16 in)
-     - 23.25 mm (15/16 in)
-     - 16.15 mm (5/8 in)
-   * - **Shell + Connector**
-     - 71.5 mm (2 7/8 in)
-     - 23.25 mm (15/16 in)
-     - 16.15 mm (5/8 in)
+    * -
+      - Length
+      - Width
+      - Height
+    * - **Shell**
+      - 59 mm (5/16 in)
+      - 23.25 mm (15/16 in)
+      - 16.15 mm (5/8 in)
+    * - **Shell + Connector**
+      - 71.5 mm (2 7/8 in)
+      - 23.25 mm (15/16 in)
+      - 16.15 mm (5/8 in)
 
 
 Connections
@@ -70,13 +70,13 @@ The CharaChorder X is plug-and-play, so it doesn’t require any
 additional software to work.
 
 .. warning::
-   IMPORTANT: During your first time plugging your CharaChorder in,
-   and every time thereafter when you have :ref:`realtime feedback<GenerativeTextMenu:Realtime Feedback>`
-   enabled, it’s recommended
-   that you have your cursor in a blank typing space. The CharaChorder
-   has a welcome message that can send instructions to your computer
-   that are not intended by the user. This feature can be disabled in
-   the :doc:`GTM<GenerativeTextMenu>`.
+    IMPORTANT: During your first time plugging your CharaChorder in,
+    and every time thereafter when you have :ref:`realtime feedback<GenerativeTextMenu:Realtime Feedback>`
+    enabled, it’s recommended
+    that you have your cursor in a blank typing space. The CharaChorder
+    has a welcome message that can send instructions to your computer
+    that are not intended by the user. This feature can be disabled in
+    the :doc:`GTM<GenerativeTextMenu>`.
 
 Take the male USB-A connector from your keyboard and plug it into the CharaChorder X's female USB-A port. After that, take the male USB'A connector on the CharaChorder X and plug it into a female USB-A port on your computer.
 
@@ -91,7 +91,7 @@ If you have :ref:`realtime feedback<GenerativeTextMenu:Realtime Feedback>` enabl
 “CCOS is ready”, your device is ready to be used.
 
 .. note::
-   IMPORTANT: :ref:`Realtime feedback<GenerativeTextMenu:Realtime Feedback>` is enabled by default on new CharaChorder devices.
+    IMPORTANT: :ref:`Realtime feedback<GenerativeTextMenu:Realtime Feedback>` is enabled by default on new CharaChorder devices.
 
 Getting Started
 ***************
@@ -114,19 +114,19 @@ below:
 #. Click “Connect” at the bottom middle of the page
 #. When the popup box comes up that reads “charachorder.io wants to connect to a serial port”, choose your CharaChorder device, then click the “connect” button
 
-   .. _Serial Port Popup Check Firmware:
-   .. image:: /assets/images/SerialPort-Message-CCX.webp
-      :width: 435
-      :alt: Popup to select serial device
+    .. _Serial Port Popup Check Firmware:
+    .. image:: /assets/images/SerialPort-Message-CCX.webp
+        :width: 435
+        :alt: Popup to select serial device
 
 After following the above steps, you can find your
 firmware version in the bottom left of your screen. It will read
 something like this: ``CCOS 2.0.2``
 
-   .. _Bottom Bar Check Firmware:
-   .. image:: /assets/images/DM-Bottom-Bar-CCX-S2.webp
-      :width: 1200
-      :alt: Checking the firmware on Device Manager
+    .. _Bottom Bar Check Firmware:
+    .. image:: /assets/images/DM-Bottom-Bar-CCX-S2.webp
+        :width: 1200
+        :alt: Checking the firmware on Device Manager
 
 Updating the Firmware
 ~~~~~~~~~~~~~~~~~~~~~
@@ -137,23 +137,23 @@ which is the latest firmware release by visiting `this
 site <https://charachorder.io/ccos/>`__.
 
 .. warning::
-   IMPORTANT: Before performing the below steps, please make sure that you have a :ref:`backup of your layout, chord library, and settings<Device Manager:Creating a Backup>`. The update might reset those, so it's important that you keep backup files handy. For instructions on how to restore backed up files, visit the :ref:`Backups<Device Manager:Restoring from a Backup>` section.
+    IMPORTANT: Before performing the below steps, please make sure that you have a :ref:`backup of your layout, chord library, and settings<Device Manager:Creating a Backup>`. The update might reset those, so it's important that you keep backup files handy. For instructions on how to restore backed up files, visit the :ref:`Backups<Device Manager:Restoring from a Backup>` section.
 
 #. On a chromium based browser, such as Chrome, go to the CharaChorder `Device Manager <https://charachorder.io/config/layout/>`__
 #. If not auto-connected, click “Connect”
 #. When the popup box comes up that reads “charachorder.io wants to connect to a serial port”, choose your CharaChorder device, then click the “connect” button
 
-   .. _Serial Port Popup Update Firmware:
-   .. image:: /assets/images/SerialPort-Message-CCX.webp
-      :width: 435
-      :alt: Popup to select serial device
+    .. _Serial Port Popup Update Firmware:
+    .. image:: /assets/images/SerialPort-Message-CCX.webp
+        :width: 435
+        :alt: Popup to select serial device
 
 #. Click on the CCOS version on the bottom left of the page
 
-   .. _Bottom Bar Update Firmware:
-   .. image:: /assets/images/DM-Bottom-Bar-CCX-S2.webp
-      :width: 1200
-      :alt: Checking the firmware on Device Manager
+    .. _Bottom Bar Update Firmware:
+    .. image:: /assets/images/DM-Bottom-Bar-CCX-S2.webp
+        :width: 1200
+        :alt: Checking the firmware on Device Manager
 
 #. You will see a list of available versions along with their release date. Click on the one you want.
 #. Click "Apply Update"
@@ -176,7 +176,7 @@ allows text entry such as a notepad app. For an explanation on chords
 and how to perform them, visit the :doc:`Chords<Chords>` section.
 
 .. warning::
-   **A bug currently exists on Windows 11 default Notepad app where chording doesn't load correctly. We are looking into this, but, for now, we recommend using a different app.**
+    **A bug currently exists on Windows 11 default Notepad app where chording doesn't load correctly. We are looking into this, but, for now, we recommend using a different app.**
 
 Once you perform the chord to call up the :doc:`GTM<GenerativeTextMenu>`, your CharaChorder will type out the menu and its options.
 It will look something like this:
@@ -286,5 +286,5 @@ training website; https://www.iq-eq.io/#/
 
 .. _Dot I/O:
 .. image:: /assets/images/DOTIOL.png
-  :width: 1200
-  :alt: Practicing on DOT I/O
+    :width: 1200
+    :alt: Practicing on DOT I/O

--- a/docs/CharaChorder_Lite.rst
+++ b/docs/CharaChorder_Lite.rst
@@ -13,11 +13,11 @@ Those who would rather build onto their muscle memory on a traditional, QWERTY k
 
 .. _CCL:
 .. image:: /assets/images/CCL_1.webp
-  :width: 1200
-  :alt: CharaChorder Lite
+    :width: 1200
+    :alt: CharaChorder Lite
 
 .. contents:: Table of Contents of this Page
-   :local:
+    :local:
 
 Out of the Box
 **************
@@ -50,15 +50,15 @@ Front:
 
 .. _CCL PCB Front:
 .. image:: /assets/images/CCL-PCB-Front.png
-  :width: 1200
-  :alt: CharaChorder Lite PCB Front Side
+    :width: 1200
+    :alt: CharaChorder Lite PCB Front Side
 
 Back:
 
 .. _CCL PCB Back:
 .. image:: /assets/images/CCL-PCB-Back.png
-  :width: 1200
-  :alt: CharaChorder Lite PCB Back Side
+    :width: 1200
+    :alt: CharaChorder Lite PCB Back Side
 
 
 Key Plate
@@ -94,8 +94,8 @@ The CharaChorder Lite comes with a 60% set of Gateron Clear/White switches. Thes
 
 .. _Gateron Switch Reference:
 .. image:: /assets/images/GateronSwitches.jpeg
-  :width: 1200
-  :alt: A table comparing the different Gateron Switches
+    :width: 1200
+    :alt: A table comparing the different Gateron Switches
 
 Key Caps
 ^^^^^^^^
@@ -128,9 +128,9 @@ additional software to work.
 If not done already, make sure that the USB-C side of the :ref:`power cable<CharaChorder_Lite:Power and Communication>` is plugged into the back right of the CharaChorder Lite. It’s important to be certain that the cable is plugged all the way in; otherwise, the CharaChorder might not function as intended.
 
 .. note::
-  The CharaChorder Lite has been sold with two different chips: M0 and S2
+    The CharaChorder Lite has been sold with two different chips: M0 and S2
 
-  You can see which chip you have, by connecting to the `Device Manager <https://charachorder.io/>`__, then looking at the bottom middle of the page, after the device name:
+    You can see which chip you have, by connecting to the `Device Manager <https://charachorder.io/>`__, then looking at the bottom middle of the page, after the device name:
 
     * CharaChorder Lite M0 (bought before oct 1st, 2022)
         If you have the M0 chip, continue reading the warning and instructions about the startup message below.
@@ -139,8 +139,8 @@ If not done already, make sure that the USB-C side of the :ref:`power cable<Char
         If you have the S2 chip, then you can skip to the :ref:`Getting Started section<CharaChorder_Lite:Getting Started>`, because the startup message has been removed on instant boot devices (CCOS 2.1.0).
 
 .. warning::
-   By default, the device sends a :ref:`startup<GenerativeTextMenu:Startup>` message, on every boot or re-plug. In some cases, this can interfere with functions on your computer or cause unwanted behavior. This feature can be disabled in
-   the :doc:`GTM<GenerativeTextMenu>`.
+    By default, the device sends a :ref:`startup<GenerativeTextMenu:Startup>` message, on every boot or re-plug. In some cases, this can interfere with functions on your computer or cause unwanted behavior. This feature can be disabled in
+    the :doc:`GTM<GenerativeTextMenu>`.
 
 After making sure that the cable on the CharaChorder is properly
 plugged in, connect the USB-A side of the :ref:`power cable<CharaChorder_Lite:Power and Communication>` into
@@ -149,17 +149,17 @@ following things:
 
 - If your cursor is somewhere where text can be entered…
 
-	- You will first see the text “Loading ### Chordmaps” highlighted, and a few moments later, “CCOS is ready.”
+    - You will first see the text “Loading ### Chordmaps” highlighted, and a few moments later, “CCOS is ready.”
 
 - Regardless of whether or not your cursor is somewhere where text can be entered…
 
-	- You will be able to see your keyboard's lights flash from left to right, then go completely dark. After a few moments, the entire keyboard will be lit up with the LED backlighting.
+    - You will be able to see your keyboard's lights flash from left to right, then go completely dark. After a few moments, the entire keyboard will be lit up with the LED backlighting.
 
 If you have :ref:`startup<GenerativeTextMenu:Startup>` enabled, once you can see the highlighted text that reads
 “CCOS is ready.”, your device is ready to be used. If you have :ref:`LEDs<GenerativeTextMenu:LEDs (CharaChorder Lite only)>` turned on, once you see all of the lights turned on and static, your device is ready to be used.
 
 .. note::
-   The :ref:`Startup message<GenerativeTextMenu:Startup>` is enabled by default on new CharaChorder devices.
+    The :ref:`Startup message<GenerativeTextMenu:Startup>` is enabled by default on new CharaChorder devices.
 
 Getting Started
 ***************
@@ -173,10 +173,10 @@ Updating your Device
 --------------------
 
 .. warning::
-   IMPORTANT: If your device shipped from our warehouse before 2023,
-   it’s possible that it is running an obsolete firmware. You can read
-   instructions on how to upgrade your device to our new CCOS :ref:`here<CCOS:Upgrade to CCOS>`. If your device is not running    :doc:`CCOS<CCOS>`, you will be unable to follow the
-   steps below to update your device.
+    IMPORTANT: If your device shipped from our warehouse before 2023,
+    it’s possible that it is running an obsolete firmware. You can read
+    instructions on how to upgrade your device to our new CCOS :ref:`here<CCOS:Upgrade to CCOS>`. If your device is not running    :doc:`CCOS<CCOS>`, you will be unable to follow the
+    steps below to update your device.
 
 Checking your Device’s Firmware
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -188,19 +188,19 @@ below:
 #. Click “Connect” at the bottom middle of the page
 #. When the popup box comes up that reads “charachorder.io wants to connect to a serial port”, choose your CharaChorder device, then click the “connect” button
 
-   .. _Serial Port Popup Check Firmware:
-   .. image:: /assets/images/SerialPort-Message-CCL.webp
-      :width: 435
-      :alt: Popup to select serial device
+    .. _Serial Port Popup Check Firmware:
+    .. image:: /assets/images/SerialPort-Message-CCL.webp
+        :width: 435
+        :alt: Popup to select serial device
 
 After following the above steps, you can find your
 firmware version in the bottom left of your screen. It will read
 something like this: ``CCOS 2.1.0``
 
-   .. _Bottom Bar Check Firmware:
-   .. image:: /assets/images/DM-Bottom-Bar-CCL-S2.webp
-      :width: 1200
-      :alt: Checking the firmware on Device Manager
+    .. _Bottom Bar Check Firmware:
+    .. image:: /assets/images/DM-Bottom-Bar-CCL-S2.webp
+        :width: 1200
+        :alt: Checking the firmware on Device Manager
 
 Updating the Firmware
 ~~~~~~~~~~~~~~~~~~~~~
@@ -211,23 +211,23 @@ which is the latest firmware release by visiting `this
 site <https://charachorder.io/ccos/>`__.
 
 .. warning::
-   IMPORTANT: Before performing the below steps, please make sure that you have a :ref:`backup of your layout, chord library, and settings<Device Manager:Creating a Backup>`. The update might reset those, so it's important that you keep backup files handy. For instructions on how to restore backed up files, visit the :ref:`Backups<Device Manager:Restoring from a Backup>` section.
+    IMPORTANT: Before performing the below steps, please make sure that you have a :ref:`backup of your layout, chord library, and settings<Device Manager:Creating a Backup>`. The update might reset those, so it's important that you keep backup files handy. For instructions on how to restore backed up files, visit the :ref:`Backups<Device Manager:Restoring from a Backup>` section.
 
 #. On a chromium based browser, such as Chrome, go to the CharaChorder `Device Manager <https://charachorder.io/config/layout/>`__
 #. If not auto-connected, click “Connect”
 #. When the popup box comes up that reads “charachorder.io wants to connect to a serial port”, choose your CharaChorder device, then click the “connect” button
 
-   .. _Serial Port Popup Update Firmware:
-   .. image:: /assets/images/SerialPort-Message-CCL.webp
-      :width: 435
-      :alt: Popup to select serial device
+    .. _Serial Port Popup Update Firmware:
+    .. image:: /assets/images/SerialPort-Message-CCL.webp
+        :width: 435
+        :alt: Popup to select serial device
 
 #. Click on the CCOS version on the bottom left of the page
 
-   .. _Bottom Bar Update Firmware:
-   .. image:: /assets/images/DM-Bottom-Bar-CCL-S2.webp
-      :width: 1200
-      :alt: Checking the firmware on Device Manager
+    .. _Bottom Bar Update Firmware:
+    .. image:: /assets/images/DM-Bottom-Bar-CCL-S2.webp
+        :width: 1200
+        :alt: Checking the firmware on Device Manager
 
 #. You will see a list of available versions along with their release date. Click on the one you want.
 #. If you have a Lite S2, you'll be able to just click "Apply Update". If you device does not have that option, you have a M0 device and can follow the steps on screen to update your device.
@@ -271,12 +271,12 @@ Learning the Layout
 -------------------
 
 .. Note::
-	This section assumes that you are using your CharaChorder device with a US International OS layout selected on your computer. For instructions on how to change your OS layout, visit this :ref:`page<ChangingLanguage>`.
+    This section assumes that you are using your CharaChorder device with a US International OS layout selected on your computer. For instructions on how to change your OS layout, visit this :ref:`page<ChangingLanguage>`.
 
 .. _CCLLayout:
 .. image:: /assets/images/LiteLayout.png
-  :width: 1200
-  :alt: Image showing the CharaChorder Lite default layout
+    :width: 1200
+    :alt: Image showing the CharaChorder Lite default layout
 
 The CharaChorder Lite's layout is mostly traditional QWERTY. All of the letters and numbers are where you would expect them on other keyboards. However, there are some keys that are moved around, and a couple of extra keys as well. We'll describe the Lite's layout below. Remember that you can always :ref:`remap<Device Manager:Remapping>` the keys to your liking on the `CharaChorder Device Manager <https://charachorder.io>`__.
 
@@ -312,8 +312,8 @@ map the A1 access key, which bears the name “KM_1_R” or “KM_1_L”, on the
 :doc:`layout manager<Device Manager>` site. There is no real need to map the A1 access keys.
 
 .. image:: /assets/images/LiteLayoutAlpha.png
-  :width: 1200
-  :alt: The default A1 layer on the CharaChorder Lite
+    :width: 1200
+    :alt: The default A1 layer on the CharaChorder Lite
 
 A2 Layer
 ^^^^^^^^
@@ -330,8 +330,8 @@ need to :doc:`chord<Chords>` the keys together; it’s only required that the
 A2 Layer access key is pressed while the target key is pressed.
 
 .. image:: /assets/images/LiteLayoutNumber.png
-  :width: 1200
-  :alt: The default A2 layer on the CharaChorder Lite
+    :width: 1200
+    :alt: The default A2 layer on the CharaChorder Lite
 
 A3 Layer
 ^^^^^^^^
@@ -348,8 +348,8 @@ together; it’s only required that the A3 layer access key is pressed
 while the target key is pressed.
 
 .. image:: /assets/images/LiteLayoutFunction.png
-  :width: 1200
-  :alt: The default A3 layer on the CharaChorder Lite
+    :width: 1200
+    :alt: The default A3 layer on the CharaChorder Lite
 
 
 Shift Modifier
@@ -404,5 +404,5 @@ training website; https://www.iq-eq.io/#/
 
 .. _Dot I/O:
 .. image:: /assets/images/DOTIO-lite.jpeg
-  :width: 1200
-  :alt: Practicing on DOT I/O
+    :width: 1200
+    :alt: Practicing on DOT I/O

--- a/docs/Chords.rst
+++ b/docs/Chords.rst
@@ -5,7 +5,7 @@ chording ability. Read this section to learn what
 chording is and how you can benefit from it on your own CharaChorder.
 
 .. contents::  Table of Contents of this Page
-   :local:
+    :local:
 
 What are Chords?
 ----------------
@@ -150,23 +150,23 @@ OUTPUT 5. CONFIRM INPUT
 
 .. _Impulse chording one:
 .. image:: /assets/images/Impulsegif.gif
-  :width: 1200
-  :alt: Impulse chording on the CharaChorder One
+    :width: 1200
+    :alt: Impulse chording on the CharaChorder One
 
 1. Anywhere that you can see a cursor, chord the input you want
-   (example: ``b+u+r+s+t``). You will either see a jumble of letters
-   (example: “tsubr”) or you will see a chord which is already
-   programmed to that input. If you continue, any conflicts will be
-   overwritten.
+    (example: ``b+u+r+s+t``). You will either see a jumble of letters
+    (example: “tsubr”) or you will see a chord which is already
+    programmed to that input. If you continue, any conflicts will be
+    overwritten.
 2. Call the impulse command the hard
-   coded chord ``i+DUP``.
+    coded chord ``i+DUP``.
 3. Follow the prompt and type your output in character entry mode.
-   (example: >I<mpulse output: burst ).
+    (example: >I<mpulse output: burst ).
 4. Press enter to confirm your output.
 5. Verify that the desired input is correct (you will see a confirmation
-   message similar to this: >I<mpulse input: b + r + u + t + s).
+    message similar to this: >I<mpulse input: b + r + u + t + s).
 6. If the input is incorrect, perform your desired input at this step.
-   Once the input is the desired input, press enter.
+    Once the input is the desired input, press enter.
 
 These steps should take 1-3 seconds.
 
@@ -179,23 +179,23 @@ OUTPUT, 5. CONFIRM INPUT
 
 .. _Impulse chording lite:
 .. image:: /assets/images/Impulsegif.gif
-  :width: 1200
-  :alt: Impulse chording on the CharaChorder Lite
+    :width: 1200
+    :alt: Impulse chording on the CharaChorder Lite
 
 1. Anywhere that you can see a cursor, chord the input you want
-   (example: ``b+u+r+s+t``). You will either see a jumble of letters
-   (example: “tsubr”) or you will see a chord which is already
-   programmed to that input. If you continue, any conflicts will be
-   overwritten.
+    (example: ``b+u+r+s+t``). You will either see a jumble of letters
+    (example: “tsubr”) or you will see a chord which is already
+    programmed to that input. If you continue, any conflicts will be
+    overwritten.
 2. Call the impulse command with the hard
-   coded chord ``i+DUP``.
+    coded chord ``i+DUP``.
 3. Follow the prompt and type your output in character entry mode.
-   (example: >I<mpulse output: burst ).
+    (example: >I<mpulse output: burst ).
 4. Press enter to confirm your output.
 5. Verify that the desired input is correct (you will see a confirmation
-   message similar to this: >I<mpulse input: b + r + u + t + s).
+    message similar to this: >I<mpulse input: b + r + u + t + s).
 6. If the input is incorrect, perform your desired input at this step.
-   Once the input is the desired input, press enter.
+    Once the input is the desired input, press enter.
 
 These steps should take 1-3 seconds.
 
@@ -208,24 +208,24 @@ OUTPUT, 5. CONFIRM INPUT
 
 .. _Impulse chording X:
 .. image:: /assets/images/Impulsexgif.gif
-  :width: 1200
-  :alt: Impulse chording on the CharaChorder X
+    :width: 1200
+    :alt: Impulse chording on the CharaChorder X
 
 1. Anywhere that you can see a cursor, chord the input you want
-   (example: ``b+u+r+s+t``). You will either see a jumble of letters
-   (example: “tsubr”) or you will see a chord which is already
-   programmed to that input. If you continue, any conflicts will be
-   overwritten.
+    (example: ``b+u+r+s+t``). You will either see a jumble of letters
+    (example: “tsubr”) or you will see a chord which is already
+    programmed to that input. If you continue, any conflicts will be
+    overwritten.
 2. Call the impulse command with the hard
-   coded chord ``i+ESC``.
+    coded chord ``i+ESC``.
 3. Follow the prompt and type your output in character entry mode.
-   (example: >I<mpulse output: burst ).
+    (example: >I<mpulse output: burst ).
 4. Press enter to confirm your output.
 5. Verify that the desired output is correct (you will see a
-   confirmation message similar to this: >I<mpulse input: b + u + r +
-   s + t).
+    confirmation message similar to this: >I<mpulse input: b + u + r +
+    s + t).
 6. If the input is incorrect, perform your desired input at this step.
-   Once the input is the desired input, press enter.
+    Once the input is the desired input, press enter.
 
 These steps should take 1-3 seconds
 
@@ -236,13 +236,13 @@ Multiple chords in a row can have a unique output.
 
 We can create compound chords like these:
 
-   * ``website`` and ``charachorder`` can output the url: ``www.charachorder.com``
-   * ``boat`` and ``big`` can output: ``ship``
-   * ``car`` and ``car`` can output: ``traffic``
+* ``website`` and ``charachorder`` can output the url: ``www.charachorder.com``
+* ``boat`` and ``big`` can output: ``ship``
+* ``car`` and ``car`` can output: ``traffic``
 
 .. note::
 
-   The second or additional chords have to be pressed within the :ref:`Compound timeout<Compound Timeout Setting>`, by default it's one second (1000 ms).
+    The second or additional chords have to be pressed within the :ref:`Compound timeout<Compound Timeout Setting>`, by default it's one second (1000 ms).
 
 Add a compound chord
 ^^^^^^^^^^^^^^^^^^^^
@@ -253,10 +253,10 @@ First, we decide what the compound chord should output. Then, we choose one or m
 
 If we want the compound chord output: ``www.charachorder.com``
 
-   * With chord input 1: ``w+b+s+t``
-   * Output: ``website``
-   * And chord input 2: ``c+h+a+r``
-   * Output: ``charachorder``
+* With chord input 1: ``w+b+s+t``
+* Output: ``website``
+* And chord input 2: ``c+h+a+r``
+* Output: ``charachorder``
 
 #. Open the impulse prompt by chording: ``i+DUP``
 #. At the impulse output prompt, type the compound chord output, one character at a time:
@@ -265,16 +265,16 @@ If we want the compound chord output: ``www.charachorder.com``
 #. At the impulse input prompt, press the first chord: ``w+b+s+t``
 #. ``impulse input: w + b + s + t``
 
-   .. note::
+    .. note::
 
-      The order of the chord input characters doesn't matter, they appear in the impulse input prompt in the order they were pressed.
+        The order of the chord input characters doesn't matter, they appear in the impulse input prompt in the order they were pressed.
 
 #. Hold ``shift`` and press ``enter``
 #. ``impulse input: w + b + s + t |``
 
-   .. Note::
+    .. Note::
 
-      The ``|`` (pipe symbol) after the chord input, indicates that it's waiting for a second chord.
+        The ``|`` (pipe symbol) after the chord input, indicates that it's waiting for a second chord.
 
 #. Press the second chord: ``c+h+a+r``
 #. ``impulse input: w + b + s + t | c + h + a + r``
@@ -282,10 +282,10 @@ If we want the compound chord output: ``www.charachorder.com``
 
 We have added a compound chord:
 
-   * Now when we chord: ``w+b+s+t``
-   * followed (:ref:`within the Compound timeout<Compound Timeout Setting>`) by the chord: ``c+h+a+r``
-   * it outputs: ``www.charachorder.com``
+* Now when we chord: ``w+b+s+t``
+* followed (:ref:`within the Compound timeout<Compound Timeout Setting>`) by the chord: ``c+h+a+r``
+* it outputs: ``www.charachorder.com``
 
 .. note::
 
-   Compound chords aren't limited to just two in a row.
+    Compound chords aren't limited to just two in a row.

--- a/docs/Device Manager.rst
+++ b/docs/Device Manager.rst
@@ -17,15 +17,15 @@ Connecting to the Device Manager
 You can follow the steps below to connect to the device manager for the first time.
 
 .. Note::
-	If you have previously selected :ref:`Auto-connect<Autoreconnect>` within that browser for the same device, you may not need to repeat these steps every time that you go to the device manager page.
+    If you have previously selected :ref:`Auto-connect<Autoreconnect>` within that browser for the same device, you may not need to repeat these steps every time that you go to the device manager page.
 
 1. On a chromium based browser, such as Chrome or Edge, go to the `CharaChorder Device Manager <https://charachorder.io>`__
 2. Click “Connect” at the bottom center of the screen
 3. When the popup box comes up that reads “charachorder.io wants to connect to a serial port”, choose your CharaChorder device, then click the “Connect” button
 
 .. image:: /assets/images/ManagerSELECTDEVICE.png
-  :width: 400
-  :alt: Image showing the dialogue box requesting permission to open a serial connection
+    :width: 400
+    :alt: Image showing the dialogue box requesting permission to open a serial connection
 
 If these steps were performed correctly, you can see the connected device name in the bottom bar where "Connect" was previously.
 
@@ -50,7 +50,7 @@ For Arch Linux, Manjaro:
 
 .. code-block:: bash
 
-	sudo usermod -aG uucp $USER
+    sudo usermod -aG uucp $USER
 
 Replace ``$USER`` with your username or use ``$USER`` to automatically reference the current user.
 Log out and log back in for the changes to take effect.
@@ -86,8 +86,8 @@ Undo and Redo
 -------------
 
 .. image:: /assets/images/ManagerUndoRedo.png
-  :width: 200
-  :alt: The Undo and Redo arrows
+    :width: 200
+    :alt: The Undo and Redo arrows
 
 Near the top left corner, the device manager has handy undo and redo buttons which do exactly what their names describe. If you're making changes to your layout, your chords, or your layout, you can step back, one change at a time, all the way back to the very first change that you made during that session. Once you're stepped back, you can step forward to redo the change(s) that was/were undone.
 
@@ -96,8 +96,8 @@ Color Scheme
 On the bottom right of the device manager, you'll see a circle with a solid color. Hovering over this circle will reveal the label "color scheme." You can click this circle to change the color scheme of the device manager. In the color scheme menu, you can choose your preferred color using a color pallette, an RGB color system, or by clicking the dropper icon to choose a color on your screen.
 
 .. image:: /assets/images/ManagerColorScheme.png
-  :width: 300
-  :alt: The Color Scheme Menu
+    :width: 300
+    :alt: The Color Scheme Menu
 
 Light and Dark Mode
 -------------------
@@ -107,13 +107,13 @@ Save Button
 -----------
 
 .. image:: /assets/images/ManagerSaveButton.png
-  :width: 200
-  :alt: The Save Button
+    :width: 200
+    :alt: The Save Button
 
 If you make changes in the :ref:`library<Device Manager:Library>`, the :ref:`layout editor<Device Manager:Layout>` or the :ref:`device menu<Device Manager:Device>`, a colored "save" button will pop up on your screen, towards the top left corner.
 
 .. Note::
-	Your changes will not take effect until you click the save button.
+    Your changes will not take effect until you click the save button.
 
 
 Device
@@ -125,8 +125,8 @@ Backup Section
 --------------
 
 .. image:: /assets/images/ManagerHistoryMenu.png
-  :width: 400
-  :alt: The Backup Menu
+    :width: 400
+    :alt: The Backup Menu
 
 The Backup Menu is home to your backups as well as the place to go to in order to restore your device by using a backup file. There are different kinds of backups that you can create and we'll cover all of them in the next section.
 
@@ -137,14 +137,14 @@ On the Device Manager, you can create backups of your chords, your layout, and e
 Creating a Backup
 ~~~~~~~~~~~~~~~~~
 .. Note::
-	In order to follow these steps, you must already have your device :ref:`connected<Device Manager:Connecting to the Device Manager>` to the device manager.
+    In order to follow these steps, you must already have your device :ref:`connected<Device Manager:Connecting to the Device Manager>` to the device manager.
 
 1. Open the Device tab and locate the "Backup" menu in the top left.
 
 2. Choose an "individual backup" to download to your computer, or select "download everything" to download a single file with all three parts. The file(s) will be downloaded in .json format.
 
-	.. note::
-		You can make individual backups of just your chords, just your layout, or just your settings. The "download everything" option will download all three of these in a single file instead of three separate files.
+    .. note::
+        You can make individual backups of just your chords, just your layout, or just your settings. The "download everything" option will download all three of these in a single file instead of three separate files.
 
 3. If prompted, select a location to save to on your computer and rename the file to your liking.
 
@@ -155,7 +155,7 @@ Restoring from a Backup
 Additionally, you can restore your chords, your layout, and your settings on the Device Manager. Follow the steps below to do so.
 
 .. Note::
-	In order to follow these steps, you must already have your device :ref:`connected<Device Manager:Connecting to the Device Manager>` to the device manager.
+    In order to follow these steps, you must already have your device :ref:`connected<Device Manager:Connecting to the Device Manager>` to the device manager.
 
 1. Open the Device tab and locate the "Backup" menu in the top left.
 
@@ -163,13 +163,13 @@ Additionally, you can restore your chords, your layout, and your settings on the
 
 3. Select a file to use to restore from. This file should be in .json format.
 
-	.. note::
-		Files that you can restore from will have been created ahead of time by following the :ref:`steps to create a backup<Device Manager:Creating a Backup>`.
+    .. note::
+        Files that you can restore from will have been created ahead of time by following the :ref:`steps to create a backup<Device Manager:Creating a Backup>`.
 
 4. If there are changes, the :ref:`save button<Device Manager:Save Button>` will appear on the top left. Note the changes in the appropriate tab. If you restored chords, check the :ref:`chords tab<Device Manager:Library>`, if you restored a layout, check the :ref:`layout tab<Device Manager:Layout>`, and if you restored settings, check the :ref:`settings tab<Device Manager:Device>`.
 
-	.. note::
-		The restore feature does NOT erase data from your device. If there is a conflict (such as a changed setting, a different key in the layout, or a chord that has a different :ref:`output<Chords:Chord Output>`), that will be overwritten by the restore file. Settings and layout backups ALWAYS overwrite everything.
+    .. note::
+        The restore feature does NOT erase data from your device. If there is a conflict (such as a changed setting, a different key in the layout, or a chord that has a different :ref:`output<Chords:Chord Output>`), that will be overwritten by the restore file. Settings and layout backups ALWAYS overwrite everything.
 
 5. Once you see the changes that the restore file made, you can click :ref:`save<Device Manager:Save Button>` to apply the changes.
 
@@ -189,21 +189,21 @@ The :ref:`boot message<GenerativeTextMenu:Startup>` and :ref:`realtime feedback<
 Additionally, you can reset some parts of your device files such as your chords, your layout, and even return to factory settings.
 
 .. image:: /assets/images/ManagerSettingsDevice.png
-  :width: 1200
-  :alt: The Device settings box
+    :width: 1200
+    :alt: The Device settings box
 
 Spurring
 --------
 
 .. dropdown:: What is Spurring?
 
-	Spurring is a ‘chording only’ mode which tells your device to output :ref:`chords<Chords:What are Chords?>` on a press event rather than a press and release event. When in spurring mode, you can press the keys of a :ref:`chord<Chords:What are Chords?>` one at a time with a much longer waiting period, which makes it a useful mode for those who want to practice chording without worrying about proper :ref:`timing<GenerativeTextMenu:Press Tolerance>`.
+    Spurring is a ‘chording only’ mode which tells your device to output :ref:`chords<Chords:What are Chords?>` on a press event rather than a press and release event. When in spurring mode, you can press the keys of a :ref:`chord<Chords:What are Chords?>` one at a time with a much longer waiting period, which makes it a useful mode for those who want to practice chording without worrying about proper :ref:`timing<GenerativeTextMenu:Press Tolerance>`.
 
-	Spurring mode also enables you to jump from one :ref:`chord<Chords:What are Chords?>` to another without releasing everything. It can provide significant speed gains when chording, but also takes away the flexibility of character entry. Spurring mode can truly maximize speed when chording if a user has chords for all of the words they want to use.
+    Spurring mode also enables you to jump from one :ref:`chord<Chords:What are Chords?>` to another without releasing everything. It can provide significant speed gains when chording, but also takes away the flexibility of character entry. Spurring mode can truly maximize speed when chording if a user has chords for all of the words they want to use.
 
 .. image:: /assets/images/ManagerSettingsSpurring.png
-  :width: 1200
-  :alt: The Spurring settings box
+    :width: 1200
+    :alt: The Spurring settings box
 
 In this box, you can enable or disable spurring mode as well as increase or decrease the :ref:`spurring timeout setting<GenerativeTextMenu:Spurring Timeout>`.
 
@@ -211,13 +211,13 @@ Arpeggiates
 -----------
 .. dropdown:: What are arpeggiates?
 
-	Arpeggiate actions are timed actions that can modify a :ref:`chord<Chords:What are Chords?>` after the chord is performed. A quick example of this is the use of :ref:`chord modifiers<Device Manager:Chord Modifiers>` after you perform the chord. You can read that section for information on how the chord modifiers work.
+    Arpeggiate actions are timed actions that can modify a :ref:`chord<Chords:What are Chords?>` after the chord is performed. A quick example of this is the use of :ref:`chord modifiers<Device Manager:Chord Modifiers>` after you perform the chord. You can read that section for information on how the chord modifiers work.
 
-	With arpeggiates enabled, you can chord the word run and then, within the :ref:`arpeggiate timeout window<GenerativeTextMenu:Arpeggiate Timeout>`, press the :ref:`past tense modifier<Device Manager:Past Tense>` for the word to be “modified” into its past tense variant; in english, ran.
+    With arpeggiates enabled, you can chord the word run and then, within the :ref:`arpeggiate timeout window<GenerativeTextMenu:Arpeggiate Timeout>`, press the :ref:`past tense modifier<Device Manager:Past Tense>` for the word to be “modified” into its past tense variant; in english, ran.
 
 .. image:: /assets/images/ManagerSettingsArpeggiates.png
-  :width: 1200
-  :alt: The Arpeggiates settings box
+    :width: 1200
+    :alt: The Arpeggiates settings box
 
 In this box, ou can enable or disable arpeggiates as well as increase or decrease the :ref:`arpeggiate timeout setting<GenerativeTextMenu:Arpeggiate Timeout>`.
 
@@ -225,16 +225,16 @@ Chord Modifiers
 ---------------
 .. dropdown:: What are chord modifiers?
 
-	Chord modifiers are actions that change a chord when :ref:`chorded<Chords:What are Chords?>` at the same time as the :ref:`chord input<Chords:Chord Input>`, or when pressed immediately after (arpeggiately) the :ref:`chord<Chords:What are Chords?>`, provided that :ref:`arpeggiates<GenerativeTextMenu:Arpeggiate>` are enabled.
+    Chord modifiers are actions that change a chord when :ref:`chorded<Chords:What are Chords?>` at the same time as the :ref:`chord input<Chords:Chord Input>`, or when pressed immediately after (arpeggiately) the :ref:`chord<Chords:What are Chords?>`, provided that :ref:`arpeggiates<GenerativeTextMenu:Arpeggiate>` are enabled.
 
-	As of February of 2024, only the CharaChorder One and CharaChorder Lite support the use of chord modifiers. Additionally, as of that same time, chord modifiers only work in English.
+    As of February of 2024, only the CharaChorder One and CharaChorder Lite support the use of chord modifiers. Additionally, as of that same time, chord modifiers only work in English.
 
-	.. note::
-		Chord modifiers are NOT the same as keyboard modifiers. Keyboard modifiers affect keys pressed on a keyboard. Those keys include ``CTRL``, ``ALT``, and ``FN``. Chord modifiers affect chords.
+    .. note::
+        Chord modifiers are NOT the same as keyboard modifiers. Keyboard modifiers affect keys pressed on a keyboard. Those keys include ``CTRL``, ``ALT``, and ``FN``. Chord modifiers affect chords.
 
 .. image:: /assets/images/ManagerSettingsModifiers.png
-  :width: 1200
-  :alt: The Chord Modifiers settings box
+    :width: 1200
+    :alt: The Chord Modifiers settings box
 
 In this box, you can read a brief explanation of chord modifiers and how to access them.
 
@@ -245,7 +245,7 @@ The capitalization modifier modifies any chord so that the first letter is capit
 The capitalization modifier is located on the ``SHIFT`` key. In the :ref:`layout editor<Device Manager:Layout>`, this key can be either "Shift Keyboard Modifier (Left)" or "Shift Keyboard Modifier (Right)".
 
 .. note::
-	If you have ``CAPS LOCK`` active, all letters in a chord will be capitalized except the first one when using this modifier.
+    If you have ``CAPS LOCK`` active, all letters in a chord will be capitalized except the first one when using this modifier.
 
 Present Tense
 ~~~~~~~~~~~~~
@@ -276,144 +276,144 @@ Character Entry
 ---------------
 .. dropdown:: What is Character Entry?
 
-	Character entry, known to the CharaChorder community as "chentry," refers to typing one character at time.
+    Character entry, known to the CharaChorder community as "chentry," refers to typing one character at time.
 
 .. image:: /assets/images/ManagerSettingsChentry.png
-  :width: 1200
-  :alt: The Character Entry settings box
+    :width: 1200
+    :alt: The Character Entry settings box
 
 In this box, you can change a few settings that relate to using your device for character entry.
 
 .. dropdown:: Swap Keymap 0 and 1
 
-	This setting will swap the behavior of the two keys on the bottom-left of the CharaChorder Lite.
+    This setting will swap the behavior of the two keys on the bottom-left of the CharaChorder Lite.
 
-	Traditional QWERTY keyboards keep the ``CTRL`` key at the bottom left corner of the keyboard with the ``GUI`` key (Command key on Mac, Windows key on Windows, Super key on Linux, etc.) to the right of the ``CTRL`` key. The CharaChorder Lite has these two keys swapped by default, which some users find odd and difficult to adjust to. A brand new CharaChorder Lite will have the ``GUI`` key at the bottom-left corner with the ``CTRL`` key to the right of the ``GUI`` key.
+    Traditional QWERTY keyboards keep the ``CTRL`` key at the bottom left corner of the keyboard with the ``GUI`` key (Command key on Mac, Windows key on Windows, Super key on Linux, etc.) to the right of the ``CTRL`` key. The CharaChorder Lite has these two keys swapped by default, which some users find odd and difficult to adjust to. A brand new CharaChorder Lite will have the ``GUI`` key at the bottom-left corner with the ``CTRL`` key to the right of the ``GUI`` key.
 
-	With this setting, you can effectively swap the two keys’ location at the level of the CCOS so that CTRL is at the bottom-left corner.
+    With this setting, you can effectively swap the two keys’ location at the level of the CCOS so that CTRL is at the bottom-left corner.
 
 .. dropdown:: Character Entry (chentry)
 
-	This setting is a toggle that disables chording capabilities on CCOS devices. It is off by default and can be enabled in case we don’t want any chording at all. This setting can be useful in cases where we don’t want to accidentally trigger chords unintentionally, such as when gaming.
+    This setting is a toggle that disables chording capabilities on CCOS devices. It is off by default and can be enabled in case we don’t want any chording at all. This setting can be useful in cases where we don’t want to accidentally trigger chords unintentionally, such as when gaming.
 
-	If your CCOS device suddenly loses its chording ability, it’s a good idea to check if this setting is toggled off.
+    If your CCOS device suddenly loses its chording ability, it’s a good idea to check if this setting is toggled off.
 
 .. dropdown:: Key Scan Rate
 
-	The scan rate, sometimes known as the “Key scan duration,” refers to the frequency at which the device checks the state of the input keys. For reference, 5 ms corresponds to 200 Hz, which means that :doc:`CCOS<CCOS>` checks the position of the keys once every 5 milliseconds, which equals 200 times in a second. Having a lower number is usually better as it makes CCOS more responsive, though the difference at low numbers is usually negligible. In the GTM, this setting is adjustable in millisecond (ms) units.
+    The scan rate, sometimes known as the “Key scan duration,” refers to the frequency at which the device checks the state of the input keys. For reference, 5 ms corresponds to 200 Hz, which means that :doc:`CCOS<CCOS>` checks the position of the keys once every 5 milliseconds, which equals 200 times in a second. Having a lower number is usually better as it makes CCOS more responsive, though the difference at low numbers is usually negligible. In the GTM, this setting is adjustable in millisecond (ms) units.
 
 .. dropdown:: Key Debounce Press
 
-	The debounce press setting refers to the time frame (measured in milliseconds) in which :doc:`CCOS<CCOS>` will filter out duplicate key activations on a press event. In other words, any duplicate activations within the given time frame will only be counted as one.
+    The debounce press setting refers to the time frame (measured in milliseconds) in which :doc:`CCOS<CCOS>` will filter out duplicate key activations on a press event. In other words, any duplicate activations within the given time frame will only be counted as one.
 
-	We should adjust this setting if we are having unintentional duplicate characters while typing. Increasing this value will lower the probability that unwanted duplicate characters will appear because it tells :doc:`CCOS<CCOS>` to wait longer before typing an additional character that’s assigned to the same switch-direction. However, having this setting set too high might also cause issues with :doc:`CCOS<CCOS>` not reading intentional double-presses, so it’s recommended to try different numbers in small increments. This setting should be used in connection with the debounce release setting.
+    We should adjust this setting if we are having unintentional duplicate characters while typing. Increasing this value will lower the probability that unwanted duplicate characters will appear because it tells :doc:`CCOS<CCOS>` to wait longer before typing an additional character that’s assigned to the same switch-direction. However, having this setting set too high might also cause issues with :doc:`CCOS<CCOS>` not reading intentional double-presses, so it’s recommended to try different numbers in small increments. This setting should be used in connection with the debounce release setting.
 
 .. dropdown:: Key Debounce Release
 
-	The debounce release setting refers to the time frame (measured in milliseconds) in which :doc:`CCOS<CCOS>` will filter out duplicate key activations on a release event. In other words, any duplicate activations within the given time frame will only be counted as one.
+    The debounce release setting refers to the time frame (measured in milliseconds) in which :doc:`CCOS<CCOS>` will filter out duplicate key activations on a release event. In other words, any duplicate activations within the given time frame will only be counted as one.
 
-	We should adjust this setting if we are having unintentional duplicate characters while typing. Increasing this value will lower the probability that unwanted duplicate characters will appear because it tells :doc:`CCOS<CCOS>` to wait longer before typing an additional character that’s assigned to the same switch-direction. However, having this setting set too high might also cause issues with :doc:`CCOS<CCOS>` not reading intentional double-presses, so it’s recommended to try different numbers in small increments. This setting should be used in connection with the debounce press setting.
+    We should adjust this setting if we are having unintentional duplicate characters while typing. Increasing this value will lower the probability that unwanted duplicate characters will appear because it tells :doc:`CCOS<CCOS>` to wait longer before typing an additional character that’s assigned to the same switch-direction. However, having this setting set too high might also cause issues with :doc:`CCOS<CCOS>` not reading intentional double-presses, so it’s recommended to try different numbers in small increments. This setting should be used in connection with the debounce press setting.
 
 .. dropdown:: Output Character Delay
 
-	This setting adds a small delay to keystroke inputs. It is measured in microseconds (μs) and is very small by default.
+    This setting adds a small delay to keystroke inputs. It is measured in microseconds (μs) and is very small by default.
 
-	You should increase this value if your computer is not accepting all of the characters output by your device, such as when using the :doc:`GTM<GenerativeTextMenu>`. If you are having this issue, your :doc:`GTM<GenerativeTextMenu>` would look weird, with missing chunks or characters.
+    You should increase this value if your computer is not accepting all of the characters output by your device, such as when using the :doc:`GTM<GenerativeTextMenu>`. If you are having this issue, your :doc:`GTM<GenerativeTextMenu>` would look weird, with missing chunks or characters.
 
-	If you have a faster computer, then you can lower this setting to make chording and the :doc:`GTM<GenerativeTextMenu>` feel snappier and more responsive.
+    If you have a faster computer, then you can lower this setting to make chording and the :doc:`GTM<GenerativeTextMenu>` feel snappier and more responsive.
 
 Mouse
 -----
 .. dropdown:: Mouse???
 
-	:doc:`CCOS<CCOS>` has mouse functionality. This means that your CharaChorder, or CCOS-powered keyboard, has the ability to control your computer's mouse. These settings affect the mouse usage on your CharaChorder.
+    :doc:`CCOS<CCOS>` has mouse functionality. This means that your CharaChorder, or CCOS-powered keyboard, has the ability to control your computer's mouse. These settings affect the mouse usage on your CharaChorder.
 
 .. image:: /assets/images/ManagerSettingsMouse.png
-  :width: 1200
-  :alt: The Mouse settings box
+    :width: 1200
+    :alt: The Mouse settings box
 
 In this box, you can adjust settings relating to :doc:`CCOS'<CCOS>` mouse abilities.
 
 .. dropdown:: Mouse Speed(s)
 
-	:doc:`CCOS<CCOS>` has two mouse speeds, a fast speed and a slow speed. The slow speed is activated when you use only one of the mouse keys in a single direction (as opposed to using 2 keys in the same direction). The fast speed is activated when you use two mouse keys in a single direction (as opposed to using only one key in the same direction).
+    :doc:`CCOS<CCOS>` has two mouse speeds, a fast speed and a slow speed. The slow speed is activated when you use only one of the mouse keys in a single direction (as opposed to using 2 keys in the same direction). The fast speed is activated when you use two mouse keys in a single direction (as opposed to using only one key in the same direction).
 
-	You can read a more in-depth explanation of mouse speeds in the :ref:`GTM section<GenerativeTextMenu:Slow Speed>`.
+    You can read a more in-depth explanation of mouse speeds in the :ref:`GTM section<GenerativeTextMenu:Slow Speed>`.
 
 .. dropdown:: Scroll Speed
 
-	Scroll speed refers to the speed at which your :doc:`CCOS<CCOS>` scroll will scroll.
+    Scroll speed refers to the speed at which your :doc:`CCOS<CCOS>` scroll will scroll.
 
-	You can read a more in-depth explanation of the scroll speed in the :ref:`GTM section<GenerativeTextMenu:Scroll Speed>`.
+    You can read a more in-depth explanation of the scroll speed in the :ref:`GTM section<GenerativeTextMenu:Scroll Speed>`.
 
 .. dropdown:: Active Mouse
 
-	Active mode nudges your mouse cursor one pixel every minute or so (not a specific timing). This setting can be used to keep your computer from going to sleep. You might turn this setting off if you notice desktop apps are preventing you from getting mobile notifications (for example on Discord or Microsoft Teams).
+    Active mode nudges your mouse cursor one pixel every minute or so (not a specific timing). This setting can be used to keep your computer from going to sleep. You might turn this setting off if you notice desktop apps are preventing you from getting mobile notifications (for example on Discord or Microsoft Teams).
 
 .. dropdown:: Poll Rate
 
-	The polling rate (poll rate) is the frequency at which data from the CharaChorder’s mouse functionality is sent to the device it’s connected to. In other words, how often it updates the cursor’s position to the computer.
+    The polling rate (poll rate) is the frequency at which data from the CharaChorder’s mouse functionality is sent to the device it’s connected to. In other words, how often it updates the cursor’s position to the computer.
 
-	You can read a more in-depth explanation of the polling rate in the :ref:`GTM section<GenerativeTextMenu:Poll Rate>`.
+    You can read a more in-depth explanation of the polling rate in the :ref:`GTM section<GenerativeTextMenu:Poll Rate>`.
 
 Chording
 --------
 .. dropdown:: What is Chording?
 
-	Chording is the beautiful ability of pressing multiple keys at a time to get a predefined output, whether it's a single word, an entire phrase, or important addresses.
+    Chording is the beautiful ability of pressing multiple keys at a time to get a predefined output, whether it's a single word, an entire phrase, or important addresses.
 
-	A chord is a type of input/output action on a keyboard: you press two or more keys at the same time and release them at the same time, after which a predefined output will replace the originally pressed keys.
+    A chord is a type of input/output action on a keyboard: you press two or more keys at the same time and release them at the same time, after which a predefined output will replace the originally pressed keys.
 
-	By chording, we are able to type one word at a time instead of one letter at a time. It’s even possible to have chords for phrases and entire sentences.
+    By chording, we are able to type one word at a time instead of one letter at a time. It’s even possible to have chords for phrases and entire sentences.
 
 .. image:: /assets/images/ManagerSettingsChording.png
-  :alt: The Chording settings
+    :alt: The Chording settings
 
 In this box, you can adjust settings relating to :doc:`CCOS'<CCOS>` :doc:`chording<Chords>` abilities as well as turn off :doc:`chording<Chords>` altogether, should you choose to.
 
 .. dropdown:: Press Tolerance
 
-	The press tolerance refers to a window of time in which a chord can be performed, measured in milliseconds (ms). This timer is initiated upon the first “press” action of the first key in a chord and ends once the last key of the chord is pressed, or until the press tolerance runs out, whichever comes first. Read the :ref:`GTM section<GenerativeTextMenu:Press Tolerance>` for a more in-depth explanation.
+    The press tolerance refers to a window of time in which a chord can be performed, measured in milliseconds (ms). This timer is initiated upon the first “press” action of the first key in a chord and ends once the last key of the chord is pressed, or until the press tolerance runs out, whichever comes first. Read the :ref:`GTM section<GenerativeTextMenu:Press Tolerance>` for a more in-depth explanation.
 
 .. dropdown:: Release Tolerance
 
-	The release tolerance refers to a window of time in which a chord can be performed, measured in milliseconds (ms). This timer is initiated upon the first “release” action of any key in a chord and ends once the chord is fully performed, or until the release tolerance runs out, whichever comes first. Read the :ref:`GTM section<GenerativeTextMenu:Release Tolerance>` for a more in-depth explanation.
+    The release tolerance refers to a window of time in which a chord can be performed, measured in milliseconds (ms). This timer is initiated upon the first “release” action of any key in a chord and ends once the chord is fully performed, or until the release tolerance runs out, whichever comes first. Read the :ref:`GTM section<GenerativeTextMenu:Release Tolerance>` for a more in-depth explanation.
 
 .. _Compound Timeout Setting:
 .. dropdown:: Compound timeout
 
-	The Compound timeout determines if a :ref:`compound chord<Chords:Compound Chords>` succeeds or fails.
+    The Compound timeout determines if a :ref:`compound chord<Chords:Compound Chords>` succeeds or fails.
 
-	If the time between the individual chords in a compound chord is:
+    If the time between the individual chords in a compound chord is:
 
-	* less than the Compound timeout, then it succeeds and the individual chords are replaced with the compound chord's output
-	* greater than the Compound timeout, then it fails and the individual chords remain
+    * less than the Compound timeout, then it succeeds and the individual chords are replaced with the compound chord's output
+    * greater than the Compound timeout, then it fails and the individual chords remain
 
 .. dropdown:: Detection method
 
-	There are three detection methods:
+    There are three detection methods:
 
-	* Latency (classic) mode. Each key is printed instantly and backspaced after a successful chord.
-	* Smart adds a small amount of latency depending on your tolerances, and only prints characters when it is no longer plausible for the inputs to be a chord input.
-	* Continuous (spurring) allows you to jump from one chord to the next without releasing all keys, with more potential speed traded against the flexibility of character entry.
+    * Latency (classic) mode. Each key is printed instantly and backspaced after a successful chord.
+    * Smart adds a small amount of latency depending on your tolerances, and only prints characters when it is no longer plausible for the inputs to be a chord input.
+    * Continuous (spurring) allows you to jump from one chord to the next without releasing all keys, with more potential speed traded against the flexibility of character entry.
 
 Autocorrect
 -----------
 
 .. image:: /assets/images/ManagerSettingsAutocorrect.png
-  :alt: The Autocorrect settings
+    :alt: The Autocorrect settings
 
 .. dropdown:: Maximum attempts
 
-	Set to 0 to turn off autocorrect. An attempt is every stroke from the first keypress to the next full release. Recommended to turn off when you are comfortable using Quickfix.
+    Set to 0 to turn off autocorrect. An attempt is every stroke from the first keypress to the next full release. Recommended to turn off when you are comfortable using Quickfix.
 
 .. dropdown:: Timeout
 
-	This setting will change how long CCOS counts time in order to replace characters that precede a chord.
+    This setting will change how long CCOS counts time in order to replace characters that precede a chord.
 
-	CCOS devices have a running timer that starts after every single character that is entered in traditional chentry (character entry, i.e. one letter at a time). This timer controls whether or not the next chord that you perform deletes the preceding characters.
+    CCOS devices have a running timer that starts after every single character that is entered in traditional chentry (character entry, i.e. one letter at a time). This timer controls whether or not the next chord that you perform deletes the preceding characters.
 
-	This feature allows users to misfire chords, yet be able to correct them by quickly performing the chord correctly, without having to backspace manually to erase the misfired chord. The result is that the timeout will automatically backspace all of the preceding characters (up to the last breaking character) and replace them with the intended chord.
+    This feature allows users to misfire chords, yet be able to correct them by quickly performing the chord correctly, without having to backspace manually to erase the misfired chord. The result is that the timeout will automatically backspace all of the preceding characters (up to the last breaking character) and replace them with the intended chord.
 
 RGB
 ---
@@ -423,14 +423,14 @@ These settings adjust the color and brightness of your CharaChorder Lite.
 
 
 .. image:: /assets/images/ManagerSettingsRGB.png
-  :width: 1200
-  :alt: The RGB settings box
+    :width: 1200
+    :alt: The RGB settings box
 
 Library
 *******
 .. image:: /assets/images/ChordManager.png
-  :width: 1200
-  :alt: A picture of the Library
+    :width: 1200
+    :alt: A picture of the Library
 
 The Library is a powerful tool that lets you add, delete and edit chords stored in your chord library. It's easy to use and quick to load. We'll go over how to use it below.
 
@@ -455,7 +455,7 @@ Creating a Chord
 You can follow the steps below to create a new chord on the device manager.
 
 .. Note::
-	In order to follow these steps, you must already have your device :ref:`connected<Device Manager:Connecting to the Device Manager>` to the device manager.
+    In order to follow these steps, you must already have your device :ref:`connected<Device Manager:Connecting to the Device Manager>` to the device manager.
 
 1. Find the "New chord" text under the :ref:`search bar<search bar>` and click it.
 
@@ -464,21 +464,21 @@ You can follow the steps below to create a new chord on the device manager.
 
     You will now see the :ref:`chord input<Chords:Chord Input>` in the left column as letters inside individual boxes. These boxed-letters will be highlighted in a color (as opposed to black or white). The color depends on your selected :ref:`color scheme<Device Manager:Color Scheme>`. You will also notice a single, floating dot highlighted in the same color off to the right of the boxed-letters.
 
-	.. Note::
-		You can add any number of chords at a time without defining the desired :ref:`chord output<Chords:Chord Output>`.
+    .. Note::
+        You can add any number of chords at a time without defining the desired :ref:`chord output<Chords:Chord Output>`.
 
-	.. Warning::
-		If you click :ref:`save<Device Manager:Save Button>`, before defining a :ref:`chord output<Chords:Chord Output>` as described in :ref:`step three<Step 3>`, any chords that you've created will save to your device with a blank output and will lead to strange behavior.
+    .. Warning::
+        If you click :ref:`save<Device Manager:Save Button>`, before defining a :ref:`chord output<Chords:Chord Output>` as described in :ref:`step three<Step 3>`, any chords that you've created will save to your device with a blank output and will lead to strange behavior.
 
 .. _Step 3:
 
 3. Click into the text box to the right of the :ref:`chord input<Chords:Chord Input>` that you created in the previous step and type your desired :ref:`chord output<Chords:Chord Output>`.
 
-	.. dropdown:: Using Action Codes
+    .. dropdown:: Using Action Codes
 
-		As you type your :ref:`chord output<Chords:Chord Output>`, you'll notice that your cursor will have a bubble with a ``+`` above it. You can click this to open the :ref:`action codes menu<Device Manager:Using Action Codes>` where you can search for specific action codes or browse through the action codes available to assign into a :ref:`chord output<Chords:Chord Output>`. Read the :ref:`action codes section<Device Manager:Using Action Codes>` for information on the different kinds of action codes.
+        As you type your :ref:`chord output<Chords:Chord Output>`, you'll notice that your cursor will have a bubble with a ``+`` above it. You can click this to open the :ref:`action codes menu<Device Manager:Using Action Codes>` where you can search for specific action codes or browse through the action codes available to assign into a :ref:`chord output<Chords:Chord Output>`. Read the :ref:`action codes section<Device Manager:Using Action Codes>` for information on the different kinds of action codes.
 
-	As you type, you'll notice that your text has changed color to match your :ref:`color scheme<Device Manager:Color Scheme>` and that the end of your text has a floating dot immediately to the right.
+    As you type, you'll notice that your text has changed color to match your :ref:`color scheme<Device Manager:Color Scheme>` and that the end of your text has a floating dot immediately to the right.
 
 4. Once you are satisfied with your :ref:`output<Chords:Chord Output>`, you can proceed to modify another chord or click :ref:`save<Device Manager:Save Button>`.
 
@@ -488,20 +488,20 @@ Deleting a Chord
 You can follow the steps below to delete a chord in the device manager.
 
 .. Note::
-	In order to follow these steps, you must already have your device :ref:`connected<Device Manager:Connecting to the Device Manager>` to the device manager.
+    In order to follow these steps, you must already have your device :ref:`connected<Device Manager:Connecting to the Device Manager>` to the device manager.
 
 1. Locate the chord that you would like to delete.
 
 2. When you hover over the chord that you would like to delete, you will notice a small trash icon appear in line with that chord map. Click the trash icon in order to mark it for deletion.
 
-	When you click the trash icon, the boxed-letters in the left column will have a line through them and they will turn red. You can unmark chords for deletion by clicking the "undo" arrow next to the trash icon. The chord will return to its original color and the line will disappear.
+    When you click the trash icon, the boxed-letters in the left column will have a line through them and they will turn red. You can unmark chords for deletion by clicking the "undo" arrow next to the trash icon. The chord will return to its original color and the line will disappear.
 
-	.. Tip::
-		You can mark multiple chords for deletion at a time. Flipping through the pages in your chord library will not unmark the chords that you have marked for deletion.
+    .. Tip::
+        You can mark multiple chords for deletion at a time. Flipping through the pages in your chord library will not unmark the chords that you have marked for deletion.
 
 3. Once you have marked the undesired chords for deletion and are ready to delete them, click the :ref:`save button<Device Manager:Save Button>`.
 
-	Once you click save, the marked chord maps will disappear from the list.
+    Once you click save, the marked chord maps will disappear from the list.
 
 
 Editing a Chord
@@ -509,7 +509,7 @@ Editing a Chord
 You can follow the steps below to edit an existing chord in the device manager.
 
 .. Note::
-	In order to follow these steps, you must already have your device :ref:`connected<Device Manager:Connecting to the Device Manager>` to the device manager.
+    In order to follow these steps, you must already have your device :ref:`connected<Device Manager:Connecting to the Device Manager>` to the device manager.
 
 1. Locate the chord that you would like to edit.
 
@@ -517,16 +517,17 @@ You can follow the steps below to edit an existing chord in the device manager.
 
 3. Edit the :ref:`chord output<Chords:Chord Output>` to be whatever you would like. As you type, you will notice that the text changes color to match your :ref:`color scheme<Device Manager:Color Scheme>` and that the end of your text has a floating dot immediately to the right.
 
-	.. dropdown:: Using Action Codes
+    .. dropdown:: Using Action Codes
 
-		As you type your :ref:`chord output<Chords:Chord Output>`, you'll notice that your cursor will have a bubble with a ``+`` above it. You can click this to open the :ref:`action codes menu<Device Manager:Using Action Codes>` where you can search for specific action codes or browse through the action codes available to assign into a :ref:`chord output<Chords:Chord Output>`. Read the :ref:`action codes section<Device Manager:Using Action Codes>` for information on the different kinds of action codes.
+        As you type your :ref:`chord output<Chords:Chord Output>`, you'll notice that your cursor will have a bubble with a ``+`` above it. You can click this to open the :ref:`action codes menu<Device Manager:Using Action Codes>` where you can search for specific action codes or browse through the action codes available to assign into a :ref:`chord output<Chords:Chord Output>`. Read the :ref:`action codes section<Device Manager:Using Action Codes>` for information on the different kinds of action codes.
 
-	.. Tip::
-		You can edit multiple chords before :ref:`saving<Device Manager:Save Button>` your changes. Flipping through the pages in your chord library will not undo the changes that you have made to your existing chords.
+    .. Tip::
+        You can edit multiple chords before :ref:`saving<Device Manager:Save Button>` your changes. Flipping through the pages in your chord library will not undo the changes that you have made to your existing chords.
 
 4. Once you are ready to :ref:`save<Device Manager:Save Button>` your changes, click :ref:`save<Device Manager:Save Button>`.
 
-	Once you click :ref:`save<Device Manager:Save Button>`, the chord(s) that you've modified will change color to match the rest of the list and the floating dot will disappear.
+    Once you click :ref:`save<Device Manager:Save Button>`, the chord(s) that you've modified will change color to match the rest of the list and the floating dot will disappear.
+
 
 Share button
 ------------
@@ -545,35 +546,35 @@ Layer Selector
 
 .. dropdown:: Explanation of Layers on CCOS Devices
 
-	As of February of 2024, :doc:`CCOS<CCOS>` devices come with three (3) layers that you can make use of: the base layer, called the A1 (Alpha) layer, the secondary layer, referred to as A2 (Numeric), and the tertiary layer, named A3 (Function).
+    As of February of 2024, :doc:`CCOS<CCOS>` devices come with three (3) layers that you can make use of: the base layer, called the A1 (Alpha) layer, the secondary layer, referred to as A2 (Numeric), and the tertiary layer, named A3 (Function).
 
-	In order to access layers, you need to press and hold a "layer access" button. You MUST hold the button in order to use keys mapped to layers other than the alpha layer. The alpha layer is active by default.
+    In order to access layers, you need to press and hold a "layer access" button. You MUST hold the button in order to use keys mapped to layers other than the alpha layer. The alpha layer is active by default.
 
-	.. note::
-		In this section, we’ll refer only to the default layouts on CCOS devices. If you have modified your layout to something different, then the next portion might not be accurate for your device. If you have purchased your device from CharaChorder, then the following is accurate to your device.
+    .. note::
+        In this section, we’ll refer only to the default layouts on CCOS devices. If you have modified your layout to something different, then the next portion might not be accurate for your device. If you have purchased your device from CharaChorder, then the following is accurate to your device.
 
-	**A1 Layer**
+    **A1 Layer**
 
-	The A1 layer, also known as the alpha layer, is the main layer that is active by default. Your device will always be in the A1 layer upon boot.
+    The A1 layer, also known as the alpha layer, is the main layer that is active by default. Your device will always be in the A1 layer upon boot.
 
-	**A2 Layer**
+    **A2 Layer**
 
-	The A2 layer, sometimes referred to as the numeric layer, is accessible with the :doc:`A2 access key<CharaChorder Keys>`. In the Device Manager, this key has the name “Numeric Layer (Left)” and “Numeric Layer (Right)”, one for each hand.
+    The A2 layer, sometimes referred to as the numeric layer, is accessible with the :doc:`A2 access key<CharaChorder Keys>`. In the Device Manager, this key has the name “Numeric Layer (Left)” and “Numeric Layer (Right)”, one for each hand.
 
-	The A2 Layer is accessible by pressing and holding one layer access button. Any key that is mapped to the A2 Layer can only be accessed by pressing and holding the A2 Layer access key along with the target key. You do not need to :doc:`chord<Chords>` the keys together; it’s only required that the A2 Layer access key is pressed while the target key is pressed.
+    The A2 Layer is accessible by pressing and holding one layer access button. Any key that is mapped to the A2 Layer can only be accessed by pressing and holding the A2 Layer access key along with the target key. You do not need to :doc:`chord<Chords>` the keys together; it’s only required that the A2 Layer access key is pressed while the target key is pressed.
 
-	**A3 Layer**
+    **A3 Layer**
 
-	The A3 layer, sometimes referred to as the “function layer”, is accessible with the :doc:`A3 access key<CharaChorder Keys>`. In the Device Manager, this key is assignable by the names “Function Layer (Left)” and “Function Layer (Right)”.
+    The A3 layer, sometimes referred to as the “function layer”, is accessible with the :doc:`A3 access key<CharaChorder Keys>`. In the Device Manager, this key is assignable by the names “Function Layer (Left)” and “Function Layer (Right)”.
 
-	Once you've mapped the A3 layer access buttons, the A3 Layer is accessible by pressing and holding either one of them. You do not have to hold them both in order to access the A3 layer. Any key that is on the A3 Layer can only be accessed by pressing and holding the :doc:`A3 access key<CharaChorder Keys>`, along with the target key. You do not need to :doc:`chord<Chords>` the keys together; it’s only required that the A3 layer access key is pressed while the target key is pressed.
+    Once you've mapped the A3 layer access buttons, the A3 Layer is accessible by pressing and holding either one of them. You do not have to hold them both in order to access the A3 layer. Any key that is on the A3 Layer can only be accessed by pressing and holding the :doc:`A3 access key<CharaChorder Keys>`, along with the target key. You do not need to :doc:`chord<Chords>` the keys together; it’s only required that the A3 layer access key is pressed while the target key is pressed.
 
 .. Note::
-	The following section assumes that you have already :ref:`connected<Device Manager:Connecting to the Device Manager>` your device to the device manager.
+    The following section assumes that you have already :ref:`connected<Device Manager:Connecting to the Device Manager>` your device to the device manager.
 
 .. image:: /assets/images/ManagerLayoutSelector.png
-  :width: 300
-  :alt: Image of the Layer Selector bar
+    :width: 300
+    :alt: Image of the Layer Selector bar
 
 Above the diagram of your device, you'll see a circle with the letters "ABC" in the middle. The circle, together with the "wings" on either side (one on the left with the numbers "123" inscribed and one on the right with "fx" stylized within), make up the layer selector. You can select any one of these to view the keys that are mapped to each location, on each layer.
 
@@ -585,7 +586,7 @@ How to Remap Your Keys
 ~~~~~~~~~~~~~~~~~~~~~~
 
 .. Note::
-	In order to follow these steps, you must already have your device :ref:`connected<Device Manager:Connecting to the Device Manager>` to the device manager.
+    In order to follow these steps, you must already have your device :ref:`connected<Device Manager:Connecting to the Device Manager>` to the device manager.
 
 1. Choose the :ref:`layer<Device Manager:Layer Selector>` where you want to change the key.
 
@@ -593,17 +594,17 @@ How to Remap Your Keys
 
 3. Use the search feature in the :ref:`action codes menu<Device Manager:Using Action Codes>` or scroll through available :ref:`action codes<Device Manager:What are Action Codes>`. Once you've found the desired :ref:`action code<Device Manager:Using Action Codes>`, click on it.
 
-	Once you select the :ref:`action code<Device Manager:Using Action Codes>`, you will notice that the layout diagram now reflects the selected :ref:`action code<Device Manager:Using Action Codes>` highlighted according to your :ref:`color scheme<Device Manager:Color Scheme>` and it will be accompanied by a floating dot.
+    Once you select the :ref:`action code<Device Manager:Using Action Codes>`, you will notice that the layout diagram now reflects the selected :ref:`action code<Device Manager:Using Action Codes>` highlighted according to your :ref:`color scheme<Device Manager:Color Scheme>` and it will be accompanied by a floating dot.
 
-	.. Tip::
-		You can edit multiple keys before :ref:`saving<Device Manager:Save Button>` your changes. Flipping through the :ref:`layers<Device Manager:Layer Selector>` will not undo the changes that you have made to the layout so far.
+    .. Tip::
+        You can edit multiple keys before :ref:`saving<Device Manager:Save Button>` your changes. Flipping through the :ref:`layers<Device Manager:Layer Selector>` will not undo the changes that you have made to the layout so far.
 
 4. Once you have changed the desired key(s), click the :ref:`save button<Device Manager:Save Button>`.
 
-	.. note::
-		Your changes will not take effect until you click :ref:`save<Device Manager:Save Button>`.
+    .. note::
+        Your changes will not take effect until you click :ref:`save<Device Manager:Save Button>`.
 
-	Once you click :ref:`save<Device Manager:Save Button>`, the highlighted key(s) will lose their highlight and the floating dot will disappear. Your layout diagram will be black and white.
+    Once you click :ref:`save<Device Manager:Save Button>`, the highlighted key(s) will lose their highlight and the floating dot will disappear. Your layout diagram will be black and white.
 
 Using Action Codes
 ~~~~~~~~~~~~~~~~~~
@@ -632,28 +633,28 @@ There are eight different categories in the action code menu. These are: ASCII M
 
 
 .. ASCII Macros
-   ,,,,,,,,,,,,,,
+    ,,,,,,,,,,,,,,
 
-   ASCII
-   ,,,,,,,,,,,
+    ASCII
+    ,,,,,,,,,,,
 
-   CharaChorder One
-   ,,,,,,,,,,,,,,,,,,,,,,,,,
+    CharaChorder One
+    ,,,,,,,,,,,,,,,,,,,,,,,,,
 
-   CharaChorder
-   ,,,,,,,,,,,,,,,,,,,,,,,,,
+    CharaChorder
+    ,,,,,,,,,,,,,,,,,,,,,,,,,
 
-   CP-1252
-   ,,,,,,,,,,,,,,,,,,,,,,,,,
+    CP-1252
+    ,,,,,,,,,,,,,,,,,,,,,,,,,
 
-   Keyboard
-   ,,,,,,,,,,,,,,,,,,,,,,,,,
+    Keyboard
+    ,,,,,,,,,,,,,,,,,,,,,,,,,
 
-   Mouse
-   ,,,,,,,,,,,,,,,,,,,,,,,,,
+    Mouse
+    ,,,,,,,,,,,,,,,,,,,,,,,,,
 
-   Key Codes
-   ,,,,,,,,,,,,,,,,,,,,,,,,,
+    Key Codes
+    ,,,,,,,,,,,,,,,,,,,,,,,,,
 
 Remove Button
 .............

--- a/docs/FAQs.rst
+++ b/docs/FAQs.rst
@@ -4,7 +4,7 @@ Frequently Asked Questions
 This page houses some Frequently Asked Questions about our technology and our devices.
 
 .. contents:: Table of Contents of this Page
-   :local:
+    :local:
 
 General FAQs
 ------------

--- a/docs/GenerativeTextMenu.rst
+++ b/docs/GenerativeTextMenu.rst
@@ -12,13 +12,13 @@ learn how to use to make the device your own.
 You will notice that some settings have different press and release values. This is because the switches are read by the :doc:`CCOS<CCOS>` at two different moments in time: when they are pressed, and when they are released. We have designed :doc:`CCOS<CCOS>` to have configurable settings for each of those "events" separately, for maximum adjustability. Intuitively, each **press** setting, such as :ref:`debounce press<GenerativeTextMenu:Debounce Press>`, will affect the way that the :doc:`CCOS<CCOS>` reads the switch at the time that the switch is pressed into any one direction. Conversely, **release** settings, such as :ref:`release debounce<GenerativeTextMenu:Debounce Release>`, will change the way that the :doc:`CCOS<CCOS>` reads the switch at the exact moment that the switch is released, or un-pressed, from any one direction.
 
 .. note::
-	Although you can configure your CCOS settings anywhere that you can type through the GTM, you can also edit them on the :doc:`CharaChorder Device Manager<Device Manager>`.
+    Although you can configure your CCOS settings anywhere that you can type through the GTM, you can also edit them on the :doc:`CharaChorder Device Manager<Device Manager>`.
 
 .. warning::
-	Please note that updating your CCOS device might reset your GTM settings to default. Please make sure that you have a :ref:`backup of your GTM settings<Device Manager:Creating a Backup>` before updating your CCOS device. For instructions on how to restore backed up files, visit the :ref:`Restoring from a Backup<Device Manager:Restoring from a Backup>` section.
+    Please note that updating your CCOS device might reset your GTM settings to default. Please make sure that you have a :ref:`backup of your GTM settings<Device Manager:Creating a Backup>` before updating your CCOS device. For instructions on how to restore backed up files, visit the :ref:`Restoring from a Backup<Device Manager:Restoring from a Backup>` section.
 
 .. contents:: Table of Contents of this Page
-   :local:
+    :local:
 
 How to access the GTM
 *********************
@@ -48,7 +48,7 @@ Navigation around this menu is based on letter-presses. In the example above, yo
 
 In some submenus, you will see numeric values. In order to increase or decrease these, you can use the up and down arrow keys on your :doc:`CCOS<CCOS>` device.
 
-	``CharaChorder > Chording > Press Tolerance [ Use up/down arrow keys to adjust: 25ms ]``
+``CharaChorder > Chording > Press Tolerance [ Use up/down arrow keys to adjust: 25ms ]``
 
 
 Available Menus
@@ -183,7 +183,7 @@ The intent of this setting is to provide more accurate key mapping. As such, it 
     "CharaChorder X", "Windows"
 
 .. Warning::
-	As of December of 2023, this setting doesn't do anything on CCOS devices.
+    As of December of 2023, this setting doesn't do anything on CCOS devices.
 
 GUI-CTRL Soft Swap (CharaChorder Lite only)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -202,15 +202,15 @@ This setting has two options: GUI-CTRL and CTRL-GUI. This setting is set to GUI-
 
 .. _GUI-CTRL:
 .. image:: /assets/images/GUI-CTRL.jpg
-  :width: 1200
-  :alt: Default CharaChorder Lite CTRL mapping
+    :width: 1200
+    :alt: Default CharaChorder Lite CTRL mapping
 
 **Key Mapping after swapping:**
 
 .. _CTRL-GUI:
 .. image:: /assets/images/CTRL-GUI.jpg
-  :width: 1200
-  :alt: Alternative CharaChorder Lite CTRL mapping
+    :width: 1200
+    :alt: Alternative CharaChorder Lite CTRL mapping
 
 Users who are used to traditional keyboard layouts will want to take advantage of this setting so they don't have to relearn the new position of the keys.
 
@@ -232,7 +232,7 @@ However, :doc:`CCOS<CCOS>` uses ms (milliseconds) which is directly inverse to H
 
     In the context of frequency and period (time duration), the relationship is inverse. Frequency is the number of cycles per second, measured in Hz. The period is the time it takes for one cycle to complete, measured in seconds (s). The formula is:
 
-	``Frequency (Hz) = 1/Period (s), where s = 1000 ms``
+    ``Frequency (Hz) = 1/Period (s), where s = 1000 ms``
 
     If you convert the period to milliseconds (ms), the relationship remains inverse. For instance, if you have a frequency of 1000 Hz, the period is 1 ms (because 1 second = 1000 milliseconds). As the frequency increases, the period (measured in ms) decreases.
 
@@ -360,8 +360,8 @@ The press tolerance refers to a window of time in which a chord can be performed
 .. _Tolerances:
 
 .. image:: /assets/images/Press-and-Release-Tolerances.png
-  :width: 1200
-  :alt: Diagram Explaining Tolerances
+    :width: 1200
+    :alt: Diagram Explaining Tolerances
 
 Put simply, increasing the press tolerance (usually, done in conjunction with increasing the :ref:`release tolerance <GenerativeTextMenu:Release Tolerance>`) makes it easier to perform chords.
 
@@ -389,8 +389,8 @@ Release Tolerance
 The release tolerance refers to a window of time in which a chord can be performed, measured in milliseconds (ms). This timer is initiated upon the first "release" action of any key in a chord and ends once the chord is fully performed, or until the release tolerance runs out, whichever comes first.
 
 .. image:: /assets/images/Press-and-Release-Tolerances.png
-  :width: 1200
-  :alt: Diagram Explaining Tolerances
+    :width: 1200
+    :alt: Diagram Explaining Tolerances
 
 Put simply, increasing the release tolerance (usually, done in conjunction with increasing the :ref:`press tolerance <GenerativeTextMenu:Press Tolerance>`) makes it easier to perform chords.
 
@@ -518,7 +518,7 @@ This setting toggles realtime feedback ON or OFF.
 Realtime feedback refers to the helpful text like ``SPURRING_ON``, ``SPURRING_OFF`` etc, that lets the user know if a certain mode has been activated or deactivated on the CharaChorder device. Since there is no other visual way to know if the chord used to enable or disable certain settings, it is helpful to have these texts pop up as confirmation.
 
 .. Note::
-	The realtime feedback setting controls the :ref:`startup<GenerativeTextMenu:Startup>` setting. If realtime feedback is OFF, then startup will be OFF, regardless of that setting's individual toggle.
+    The realtime feedback setting controls the :ref:`startup<GenerativeTextMenu:Startup>` setting. If realtime feedback is OFF, then startup will be OFF, regardless of that setting's individual toggle.
 
 Startup
 ~~~~~~~
@@ -532,7 +532,7 @@ However, if you have editable text highlighted when you connect your CharaChorde
 If you would rather not have this message display every time that you connect your device, then you can toggle this setting OFF.
 
 .. Warning::
-	The Startup setting is dependent on the :ref:`realtime feedback setting<GenerativeTextMenu:Realtime Feedback>`. If that setting is set to OFF, then Startup won't display, even if Startup is set to ON.
+    The Startup setting is dependent on the :ref:`realtime feedback setting<GenerativeTextMenu:Realtime Feedback>`. If that setting is set to OFF, then Startup won't display, even if Startup is set to ON.
 
 LEDs (CharaChorder Lite only)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -542,7 +542,7 @@ LEDs (CharaChorder Lite only)
 The :doc:`CharaChorder Lite<CharaChorder_Lite>` comes with RGB LEDs that light up the keys of the keyboard from below with a static light. This section contains settings pertaining to those LED lights.
 
 .. note::
-	LED settings only exist in the GTM for :doc:`CharaChorder Lite<CharaChorder_Lite>` devices, not on any other CharaChorder devices.
+    LED settings only exist in the GTM for :doc:`CharaChorder Lite<CharaChorder_Lite>` devices, not on any other CharaChorder devices.
 
 On/Off
 ^^^^^^
@@ -561,17 +561,17 @@ Use this setting to change the color of the LED backlights on your CharaChorder 
 .. csv-table::
     :header: "Letter", "Color"
 
-	"W", "White"
-	"R", "Red"
-	"O", "Orange"
-	"Y", "Yellow"
-	"L", "Lime"
-	"G", "Green"
-	"C", "Cyan"
-	"B", "Blue"
-	"V", "Violet"
-	"P", "Pink"
-	"M", "Multicolor"
+    "W", "White"
+    "R", "Red"
+    "O", "Orange"
+    "Y", "Yellow"
+    "L", "Lime"
+    "G", "Green"
+    "C", "Cyan"
+    "B", "Blue"
+    "V", "Violet"
+    "P", "Pink"
+    "M", "Multicolor"
 
 Please note that, as of December of 2023, the LEDs are NOT individually addressable. The color setting changes the color of ALL LEDs at the same time.
 
@@ -605,10 +605,10 @@ This section contains links which may be helpful to you. These links include:
 .. csv-table::
     :header: "Letter", "Item", "Description"
 
-	"A", "About", "Opens https://www.charachorder.com/pages/about."
-	"G", "Get started", "Opens https://www.charachorder.com/pages/get-started."
-	"D", "Discord", "Invites you to the CharaChorder Discord"
-	"T", "Training", "Opens https://iq-eq.io, our free tool to help people learn to type at the speed of thought"
-	"M", "Message Riley", "Copies Riley Keen (CharaChorder CEO)'s email address to your clipboard"
-	"L", "Learn chords", "Opens The Starter Chord List"
-	"S", "Check system updates", "Opens the CCOS version updates page"
+    "A", "About", "Opens https://www.charachorder.com/pages/about."
+    "G", "Get started", "Opens https://www.charachorder.com/pages/get-started."
+    "D", "Discord", "Invites you to the CharaChorder Discord"
+    "T", "Training", "Opens https://iq-eq.io, our free tool to help people learn to type at the speed of thought"
+    "M", "Message Riley", "Copies Riley Keen (CharaChorder CEO)'s email address to your clipboard"
+    "L", "Learn chords", "Opens The Starter Chord List"
+    "S", "Check system updates", "Opens the CCOS version updates page"

--- a/docs/Glossary.rst
+++ b/docs/Glossary.rst
@@ -5,78 +5,78 @@ Below you will find some common "uncommon" words that are used in the CharaChord
 community.
 
 .. glossary::
-   :sorted:
+    :sorted:
 
-   3D Press
-      When a switch is activated by pushing it normal to the surface of the
-      device (same as an ordinary keyboard switch).
+    3D Press
+        When a switch is activated by pushing it normal to the surface of the
+        device (same as an ordinary keyboard switch).
 
-   Active Mode
-      Nudges your mouse one pixel every minute or so to keep your computer
-      from sleeping.
+    Active Mode
+        Nudges your mouse one pixel every minute or so to keep your computer
+        from sleeping.
 
-   Ambidextrous Throwover (aka Mirror Mode)
-      Entry mode designed for one-handed typing. Characters from the opposite
-      hand are mirrored to the hand which activates this feature.
+    Ambidextrous Throwover (aka Mirror Mode)
+        Entry mode designed for one-handed typing. Characters from the opposite
+        hand are mirrored to the hand which activates this feature.
 
-   Arpeggiate
-      A quick, single key press and release to indicate a suffix, prefix, or
-      modifier to be associated with a chord.
+    Arpeggiate
+        A quick, single key press and release to indicate a suffix, prefix, or
+        modifier to be associated with a chord.
 
-   Chentry
-      Shorthand for 'character entry', or typing on a chording-enabled device
-      letter by letter.
+    Chentry
+        Shorthand for 'character entry', or typing on a chording-enabled device
+        letter by letter.
 
-   Chord Modifiers
-      Inputs which, when included with a chord, change the prefix, suffix,
-      capitalization, conjugation, part of speech, language, or structure of a chord.  Note, these can be used arpeggiately.
+    Chord Modifiers
+        Inputs which, when included with a chord, change the prefix, suffix,
+        capitalization, conjugation, part of speech, language, or structure of a chord.  Note, these can be used arpeggiately.
 
-   :ref:`Compound Chords<Chords:Compound Chords>`
-      Multiple chords which behave differently when used together consecutively wihthin the :ref:`Compound timeout<Device Manager:Compound Timeout Setting>`.
-      Example: know + ledge = knowledge.
+    :ref:`Compound Chords<Chords:Compound Chords>`
+        Multiple chords which behave differently when used together consecutively wihthin the :ref:`Compound timeout<Device Manager:Compound Timeout Setting>`.
+        Example: know + ledge = knowledge.
 
-   Cursor Warping
-      When your cursor or mouse position moves ("warps") based on a chord.
-      Example: Chord " with DUP to create "" and warp your cursor inside "".
+    Cursor Warping
+        When your cursor or mouse position moves ("warps") based on a chord.
+        Example: Chord " with DUP to create "" and warp your cursor inside "".
 
-   DUP (duplicate) key
-      In character entry, it repeats your last input. In chorded entry, it is
-      used for words with repeating letters.
+    DUP (duplicate) key
+        In character entry, it repeats your last input. In chorded entry, it is
+        used for words with repeating letters.
 
-   Dynamic Chord Library
-      Advanced system feature enabling activation of multiple named chord
-      libraries through action codes embedded in chord outputs. You can have multiple chord libraries on your device, even if the chord inputs might otherwise conflict. This features allows you to have separate libraries for different settings, further allowing you to have the same input produce a different output on each different library. 
+    Dynamic Chord Library
+        Advanced system feature enabling activation of multiple named chord
+        libraries through action codes embedded in chord outputs. You can have multiple chord libraries on your device, even if the chord inputs might otherwise conflict. This features allows you to have separate libraries for different settings, further allowing you to have the same input produce a different output on each different library.
 
-      When an action
-      code activates a specific library, subsequent chord creation automatically
-      groups new chords within that library's structure, allowing for context-
-      specific chord sets (e.g., multiligual, coding, email) that can be 
-      programmatically switched during use.
+        When an action
+        code activates a specific library, subsequent chord creation automatically
+        groups new chords within that library's structure, allowing for context-
+        specific chord sets (e.g., multiligual, coding, email) that can be
+        programmatically switched during use.
 
-   Forced Chord Phenomenon
-      The experience of typing a word in character entry feeling unnatural due
-      to the development of muscle memory for chording that word.
+    Forced Chord Phenomenon
+        The experience of typing a word in character entry feeling unnatural due
+        to the development of muscle memory for chording that word.
 
-   Fluid Chorded/Character Entry
-      Default text entry mode for CharaChorder. Output characters individually
-      (like a keyboard) OR press and release multiple characters of a chord
-      simultaneously to output a chord.
+    Fluid Chorded/Character Entry
+        Default text entry mode for CharaChorder. Output characters individually
+        (like a keyboard) OR press and release multiple characters of a chord
+        simultaneously to output a chord.
 
-   GTM (Generative Text Menu)
-      A text-based menu accessible anywhere you type. It allows access to
-      various device settings and features without software. See :doc:`GenerativeTextMenu`.
+    GTM (Generative Text Menu)
+        A text-based menu accessible anywhere you type. It allows access to
+        various device settings and features without software. See :doc:`GenerativeTextMenu`.
 
-   Impulse Chord
-      An 'on-the-fly' custom chord that can be spontaneously created anywhere
-      you can type via the GTM. See :ref:`Chords:Impulse chording`.
+    Impulse Chord
+        An 'on-the-fly' custom chord that can be spontaneously created anywhere
+        you can type via the GTM. See :ref:`Chords:Impulse chording`.
 
-   Macro
-      Sequence of mouse and/or keyboard actions assigned to a chord.
+    Macro
+        Sequence of mouse and/or keyboard actions assigned to a chord.
 
-   Spurring
-      A 'chording only' mode which outputs chords on a press rather than a
-      press & release. Enables jumping from one chord to another without 
-      releasing everything. It can provide significant speed gains with chording, 
-      but also takes away the flexibility of character entry. Spurring also 
-      helps new users learn how to chord by eliminating the need to focus on 
-      timing.
+    Spurring
+        A 'chording only' mode which outputs chords on a press rather than a
+        press & release. Enables jumping from one chord to another without
+        releasing everything. It can provide significant speed gains with chording,
+        but also takes away the flexibility of character entry. Spurring also
+        helps new users learn how to chord by eliminating the need to focus on
+        timing.

--- a/docs/Layout.rst
+++ b/docs/Layout.rst
@@ -41,18 +41,21 @@ TL;DR, so what does this mean for me?
 First of all, here are some pitfalls
 
 * If you set for example `$`, the CCOS types this as "hold shift press 4 release shift".
-  Meaning if you press `$` and `3` together, **you'll actually type "$#" instead of "$3"**
-  because the CCOS needs to hold shift for typing the `$` sign
-  - *Avoid putting characters that need shift and normal characters on the same layer*
+
+    Meaning if you press `$` and `3` together, **you'll actually type "$#" instead of "$3"**
+    because the CCOS needs to hold shift for typing the `$` sign
+
+    - *Avoid putting characters that need shift and normal characters on the same layer*
+
 * Using for example a German layout on the OS will swap z and y, just like on a normal keyboard.
 * Using any non-ASCII, non-Chara, non-keyboard characters will *only* work on Windows.
 * The hacks used by Chara can have unexpected consequences in some programs which intercept raw input
 
 .. tip::
-  The easiest solution is
-  use `US-Intl <https://en.m.wikipedia.org/wiki/QWERTY#US-International>`_ on your OS.
-  You can use right-alt to access special characters.
-  Holding right-alt and pressing `q` will give you an `ä`.
+    The easiest solution is
+    use `US-Intl <https://en.m.wikipedia.org/wiki/QWERTY#US-International>`_ on your OS.
+    You can use right-alt to access special characters.
+    Holding right-alt and pressing `q` will give you an `ä`.
 
 The other solution is to use your local layout and mentally remap. So if you wanted to type the cyrillic `Ф`, you set the Russian layout on your OS, and map the key to `a` (which will send the key-code that corresponds to Ф on a Russian layout)
 
@@ -73,7 +76,7 @@ How does CharaChorder deal with this?
 If you set a layout on the CCOS, it moves the key-code locations around.
 
 .. warning::
-  Setting the letter `a` on a switch doesn't actually send "print a" to the computer - it sends a "key where the a would be on the us layout pressed" to the OS**.
+    Setting the letter `a` on a switch doesn't actually send "print a" to the computer - it sends a "key where the a would be on the us layout pressed" to the OS**.
 
 So how can I add äöüß etc when it's not on the US layout?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -81,7 +84,7 @@ So how can I add äöüß etc when it's not on the US layout?
 There is a special feature on Windows that allows you to directly type *any* Unicode character with your keyboard, by holding `alt` and typing a numeric code.
 
 .. warning::
-  Setting the letter `ä` on a switch means the device sends "hold alt press 0 press 2 press 2 press 8 release alt".
+    Setting the letter `ä` on a switch means the device sends "hold alt press 0 press 2 press 2 press 8 release alt".
 
 Because this is a Windows feature, this only works on Windows. However even this is *not* layout agnostic. Using a layout that moves letters around, like Programmer Dvorak, will completely mess up this hack as well.
 

--- a/docs/Master Forge.rst
+++ b/docs/Master Forge.rst
@@ -6,15 +6,15 @@ below to navigate to the topics that you find most relevant.
 
 .. _M4G:
 .. image:: /assets/images/M4G.webp
-  :width: 1200
-  :alt: The Master Forge
+    :width: 1200
+    :alt: The Master Forge
 
 The Master Forge bundle consists of two :ref:`Forge Digitizers<Master Forge:The Digitizers>`, a :ref:`mechanical bridge connector<Master Forge:The Bridge Connector>` to join the two, and, possibly, depending on which variation you purchased, some additional :doc:`bolt-ons<Bolt-Ons>` and :doc:`add-ons<Add-Ons>`. This section will discuss each of the items included in any of the Master Forge bundles, regardless of the specific configuration.
 
 :ref:`Click here to skip to the Getting Started Guide.<Master Forge:Getting Started>`
 
 .. contents:: Table of Contents of this Page
-   :local:
+    :local:
 
 Out of the Box
 **************
@@ -26,8 +26,8 @@ Parts
 
 .. _M4G Schema:
 .. image:: /assets/images/M4G-Separated.webp
-  :width: 1200
-  :alt: M4G parts
+    :width: 1200
+    :alt: M4G parts
 
 
 When you first receive your Master Forge Bundle, it will come in a cardboard
@@ -35,8 +35,8 @@ box. Once you open the box, you’ll find your brand new Master Forge inside its
 
 .. _M4G Case:
 .. image:: /assets/images/Case.webp
-  :width: 1200
-  :alt: Original Backer Case
+    :width: 1200
+    :alt: Original Backer Case
 
 Once you open the tactical case, you’ll meet your shiny, new Master Forge. The Master Forge consists of two digitizers with 8, 5-way switches, joined together by a :ref:`mechanical bridge connector<Master Forge:The Bridge Connector>`.
 
@@ -52,23 +52,23 @@ The front of each digitizer has a slotted rail which allows :doc:`bolt-ons<Bolt-
 
 .. _M4G Frontside:
 .. image:: /assets/images/M4G-Front.webp
-  :width: 1200
-  :alt: Picture showing the bridge connector and the ports
+    :width: 1200
+    :alt: Picture showing the bridge connector and the ports
 
-The underside of each digitizer is partially hollow to allow for cables and connections to happen in a discreet manner underneath the device. Inside the cavity, we can find two additional USB-C ports and downward facing LED clusters. 
+The underside of each digitizer is partially hollow to allow for cables and connections to happen in a discreet manner underneath the device. Inside the cavity, we can find two additional USB-C ports and downward facing LED clusters.
 
 .. _M4G Below:
 .. image:: /assets/images/M4G-Under.webp
-  :width: 1200
-  :alt: Bottom side of the Master Forge
+    :width: 1200
+    :alt: Bottom side of the Master Forge
 
 On the sides of each digitizer, you'll notice the :ref:`bookend rails<Master Forge:The Bookend Rails>`. Under each rail, on the body of the digitizer, you'll see holes for the screws that hold the bookend rails in place.
 
 
 .. _M4G Side:
 .. image:: /assets/images/M4G-Side.webp
-  :width: 1200
-  :alt: Original Backer Case
+    :width: 1200
+    :alt: Original Backer Case
 
 The Bridge Connector
 ~~~~~~~~~~~~~~~~~~~~
@@ -77,8 +77,8 @@ Out of the box, your :ref:`digitizers<Master Forge:The Digitizers>` will be conn
 
 .. _M4G Bridge Connector:
 .. image:: /assets/images/Bridge.webp
-  :width: 1200
-  :alt: The Mechanical and Electrical bridges
+    :width: 1200
+    :alt: The Mechanical and Electrical bridges
 
 Additionally, the two :ref:`digitizers<Master Forge:The Digitizers>` are connected by the electrical bridge connector, also known as the mini-connector. This piece fits inside the cavity of the :ref:`mechanical bridge connector<Master Forge:The Bridge Connector>` and should be removed BEFORE removing the mechanical bridge connector.
 
@@ -99,8 +99,8 @@ Each :ref:`digitizer<Master Forge:The Digitizers>` of the Master Forge comes wit
 
 .. _M4G Rails:
 .. image:: /assets/images/Rails.webp
-  :width: 1200
-  :alt: The three Bookend Rails
+    :width: 1200
+    :alt: The three Bookend Rails
 
 The bookend rails are made of machined aluminum and are held in place on the body of the :ref:`digitizers<Master Forge:The Digitizers>` by two (size), steel screws.
 
@@ -111,8 +111,8 @@ Included with every Master Forge order is a 3D-printed Splitter. This piece serv
 
 .. _M4G Splitter:
 .. image:: /assets/images/Splitter.webp
-  :width: 1200
-  :alt: The Splitter
+    :width: 1200
+    :alt: The Splitter
 
 The Switches
 ~~~~~~~~~~~~
@@ -123,13 +123,13 @@ Forge :ref:`digitizer<Master Forge:The Digitizers>` levers, which we will call s
 Each :ref:`digitizer<Master Forge:The Digitizers>` has eight 5-way switches. Starting from the outside on each :ref:`digitizer<Master Forge:The Digitizers>` and working inwards, the switches correspond to the following fingers; pinky, ring, middle, and index. The two switches along the "torso," that is, the inner-most side of each :ref:`digitizer<Master Forge:The Digitizers>`, correspond to the thumb. You can see what characters are on each switch by default in :doc:`Layout<Layout>`. Additionally, there are two more switches not on the “home-row” which can be accessed by the ring and middle fingers. The correct positioning of your fingers is for them to follow the arc in which the switches are laid out.
 
 .. note::
-   **IMPORTANT**: In this manual, we will refer to switches in the
-   following way, starting from the pinky finger and working inwards:
-   pinky, ring, middle, index, thumb 1, and thumb 2. The
-   switches below the “home-row” will be referred to as the aux 1 and aux 2
-   switches, where the switch further to the left on the left digitizer
-   is aux 1. Symmetrically, aux 1 is the switch furthest to the right on the
-   right half.
+    **IMPORTANT**: In this manual, we will refer to switches in the
+    following way, starting from the pinky finger and working inwards:
+    pinky, ring, middle, index, thumb 1, and thumb 2. The
+    switches below the “home-row” will be referred to as the aux 1 and aux 2
+    switches, where the switch further to the left on the left digitizer
+    is aux 1. Symmetrically, aux 1 is the switch furthest to the right on the
+    right half.
 
 Each switch has five press-able directions. Throughout this guide, we
 will use cardinal directions to refer to the directions in which each
@@ -161,16 +161,17 @@ cable that goes out to the computer inside the box. The power cable included wit
 
 .. _M4G Power Cable:
 .. image:: /assets/images/Power-Cable.webp
-  :width: 1200
-  :alt: The Power cable included with the Master Forge
+    :width: 1200
+    :alt: The Power cable included with the Master Forge
 
 Another cable that may be included with your order is a 3.2 gen 2, braided USB-C to USB-C cable. This cord is meant to be used if you choose to separate your :ref:`digitizers<Master Forge:The Digitizers>`.
 
 .. dropdown:: Things to remember if you separate your digitizers
 
     There are two main things to remember if you choose to use your Master Forge separated:
-        1. The cable that you use to connect the digitizers must be a 3.2 gen 2, C to C cable.
-        2. As pointed out in the :ref:`getting started section<Port Requirement>` of this page, power to an :doc:`anchor body<Anchor Bodies>` or :doc:`bolt-on<Bolt-Ons>` must be received through the front left USB-C port. This means that every anchor body or bolt-on that you add to your system has to be linked to the Master through the port on the front left.
+
+    1. The cable that you use to connect the digitizers must be a 3.2 gen 2, C to C cable.
+    2. As pointed out in the :ref:`getting started section<Port Requirement>` of this page, power to an :doc:`anchor body<Anchor Bodies>` or :doc:`bolt-on<Bolt-Ons>` must be received through the front left USB-C port. This means that every anchor body or bolt-on that you add to your system has to be linked to the Master through the port on the front left.
 
 Getting Started
 ***************
@@ -203,9 +204,10 @@ We can test out your preloaded chords, of which there are 500, by :doc:`chording
 .. dropdown:: Some other chords you can try
 
     Here are some other preloaded chords that you can try. You can read the section on :ref:`chord notation<Chords:Chord Notation>` for instructions on how to interpret the following chords.
-        - c+b = because
-        - m+b = maybe
-        - u+o+y = you
+
+    - c+b = because
+    - m+b = maybe
+    - u+o+y = you
 
 Now that you're up and running, and that you know how to perform chords, you can head over to the :doc:`training section<Tools>` for instructions
 on how to get started with learning your device. If you want to just
@@ -214,8 +216,8 @@ training website; https://www.iq-eq.io/#/
 
 .. _Dot I/O:
 .. image:: /assets/images/DOTIO.png
-  :width: 1200
-  :alt: Practicing on DOT I/O
+    :width: 1200
+    :alt: Practicing on DOT I/O
 
 Setting Up
 ----------
@@ -237,17 +239,17 @@ You can check your device’s current firmware by following the steps below:
 #. On a chromium based browser, such as Chrome, go to the `Device Manager <https://charachorder.io/>`__ (Linux users see :ref:`this link<serialportaccess>` for more information about configuring serial port access).
 #. Click “Connect” at the bottom center of the page.
 
-   .. _Connect Button Check Firmware:
-   .. image:: /assets/images/FW-connect-button.JPG
-      :width: 600
-      :alt: Connect Button on Device Manager
+    .. _Connect Button Check Firmware:
+    .. image:: /assets/images/FW-connect-button.JPG
+        :width: 600
+        :alt: Connect Button on Device Manager
 
 #. When the popup box comes up that reads “charachorder.io wants to connect to a serial port,” choose one of the two listed devices with the same name: Master Forge USB Serial (currently each Master Forge half is detected separately), then click the “connect” button.
 
-   .. _Serial Port Popup Check Firmware:
-   .. image:: /assets/images/SerialPort-Message-M4G.webp
-      :width: 435
-      :alt: Popup to select serial device
+    .. _Serial Port Popup Check Firmware:
+    .. image:: /assets/images/SerialPort-Message-M4G.webp
+        :width: 435
+        :alt: Popup to select serial device
 
 Now you can find your firmware version for the connected Master Forge half, at the bottom left of the page. It will read something like this: ``CCOS 2.1.0``
 
@@ -255,17 +257,17 @@ The device name is also shown at the bottom center.
 
 The left half is called: Forge M4G
 
-   .. _Bottom Bar Check Firmware M4G Left Half:
-   .. image:: /assets/images/DM-Bottom-Bar-M4G-S3.webp
-      :width: 724
-      :alt: Device Manager bottom bar, CCOS version and device name M4G (Master Forge's left half).
+    .. _Bottom Bar Check Firmware M4G Left Half:
+    .. image:: /assets/images/DM-Bottom-Bar-M4G-S3.webp
+        :width: 724
+        :alt: Device Manager bottom bar, CCOS version and device name M4G (Master Forge's left half).
 
 The right half is called: Forge M4GR
 
-   .. _Bottom Bar Check Firmware M4G Right Half:
-   .. image:: /assets/images/DM-Bottom-Bar-M4GR-S3.webp
-      :width: 724
-      :alt: Device Manager bottom bar, CCOS version and device name M4GR (Master Forge's right half).
+    .. _Bottom Bar Check Firmware M4G Right Half:
+    .. image:: /assets/images/DM-Bottom-Bar-M4GR-S3.webp
+        :width: 724
+        :alt: Device Manager bottom bar, CCOS version and device name M4GR (Master Forge's right half).
 
 To check the other half's firmware version, disconnect by clicking on the device name at the bottom center of the page. Then reconnect by clicking on the bottom center connect button and choose the other Master Forge USB Serial device.
 
@@ -275,7 +277,7 @@ Updating the Firmware
 Currently each half of the Master Forge has to be updated separately.
 
 .. warning::
-   IMPORTANT: Before updating the firmware, please make sure that you have a :ref:`backup of the Master Forge's left half (it's called Forge M4G), it has your layout, chord library, and settings<Device Manager:Creating a Backup>`. The update might reset those, so it's important that you keep backup files handy. Currently the Master Forge's right half (called Forge M4GR) only controls it's own LED settings. For instructions on how to restore backed up files, visit the :ref:`Restoring from a Backups<Device Manager:Restoring from a Backup>` section.
+    IMPORTANT: Before updating the firmware, please make sure that you have a :ref:`backup of the Master Forge's left half (it's called Forge M4G), it has your layout, chord library, and settings<Device Manager:Creating a Backup>`. The update might reset those, so it's important that you keep backup files handy. Currently the Master Forge's right half (called Forge M4GR) only controls it's own LED settings. For instructions on how to restore backed up files, visit the :ref:`Restoring from a Backups<Device Manager:Restoring from a Backup>` section.
 
 To check which is the latest firmware release for the Master Forge, here are the firmware pages for each half:
 
@@ -287,44 +289,44 @@ You can follow the steps below to update each Master Forge half:
 #. Head to the Device Manager `<https://charachorder.io/>`__
 #. Connect to the device manager by clicking the bottom middle ``Connect`` button.
 
-   .. _Connect Button Update Firmware:
-   .. image:: /assets/images/FW-connect-button.JPG
-      :width: 600
-      :alt: Connect Button on Device Manager
+    .. _Connect Button Update Firmware:
+    .. image:: /assets/images/FW-connect-button.JPG
+        :width: 600
+        :alt: Connect Button on Device Manager
 
 #. When the popup box comes up that reads “charachorder.io wants to connect to a serial port,” choose one of the two listed devices with the same name: Master Forge USB Serial (currently each Master Forge half is detected separately), then click the “connect” button.
 
-   .. _Serial Port Popup Update Firmware:
-   .. image:: /assets/images/SerialPort-Message-M4G.webp
-      :width: 435
-      :alt: Popup to select serial device
+    .. _Serial Port Popup Update Firmware:
+    .. image:: /assets/images/SerialPort-Message-M4G.webp
+        :width: 435
+        :alt: Popup to select serial device
 
-   Note, which Master Forge half we are updating first. The device name is shown at the bottom center:
+    Note, which Master Forge half we are updating first. The device name is shown at the bottom center:
 
-   The left half is called: Forge M4G
+    The left half is called: Forge M4G
 
-   .. _Bottom Bar Update Firmware M4G Left Half:
-   .. image:: /assets/images/DM-Bottom-Bar-M4G-S3.webp
-      :width: 724
-      :alt: Device Manager bottom bar, CCOS version and device name M4G (Master Forge's left half).
+    .. _Bottom Bar Update Firmware M4G Left Half:
+    .. image:: /assets/images/DM-Bottom-Bar-M4G-S3.webp
+        :width: 724
+        :alt: Device Manager bottom bar, CCOS version and device name M4G (Master Forge's left half).
 
-   The right half is called: Forge M4GR
+    The right half is called: Forge M4GR
 
-   .. _Bottom Bar Update Firmware M4G Right Half:
-   .. image:: /assets/images/DM-Bottom-Bar-M4GR-S3.webp
-      :width: 724
-      :alt: Device Manager bottom bar, CCOS version and device name M4GR (Master Forge's right half).
+    .. _Bottom Bar Update Firmware M4G Right Half:
+    .. image:: /assets/images/DM-Bottom-Bar-M4GR-S3.webp
+        :width: 724
+        :alt: Device Manager bottom bar, CCOS version and device name M4GR (Master Forge's right half).
 
 #. Click on the bottom left button: CCOS (your firmware version is listed here, for example: ``CCOS 2.1.0``).
 #. Click on the firmware version you want to install.
 #. Before you start the update, make sure that you don't type on the Master Forge while it's updating. It shouldn't take more than 30-60 seconds. The Master Forge supports over-the-air (OTA) updates, therefore it's enough to just click on the ``Apply Update`` button.
 
-   While it's updating, the device manager disconnects, and the Master Forge disconnects from the OS. In Windows, it plays a device disconnected sound. When it's done, Windows plays a device connected sound.
+    While it's updating, the device manager disconnects, and the Master Forge disconnects from the OS. In Windows, it plays a device disconnected sound. When it's done, Windows plays a device connected sound.
 
-   .. _Apply Update Button:
-   .. image:: /assets/images/DM-apply-update-button-M4G.png
-      :width: 600
-      :alt: Apply Update Button
+    .. _Apply Update Button:
+    .. image:: /assets/images/DM-apply-update-button-M4G.png
+        :width: 600
+        :alt: Apply Update Button
 
 #. Connect to the device manager and look at the CCOS x.x.x version, at the bottom left on the page, to see that the updated was successful.
 
@@ -332,88 +334,96 @@ Now repeat the steps, but pick the other Master Forge USB Serial device from the
 
 .. Dropdown: Only use in Emergency
 
-	If, for some reason, you weren't able to complete an OTA update, you can follow the steps below to update your CCOS manually.
+    If, for some reason, you weren't able to complete an OTA update, you can follow the steps below to update your CCOS manually.
 
- 	Doing it manually, the Master Forge must be updated one :ref:`digitizer<Master Forge:The Digitizers>` at a time.
- 		#. On a chromium based browser, such as Chrome, go to the CharaChorder `Device Manager <https://charachorder.io/ccos/>`__
- 		#. If not auto-connected, click "Connect"
+    Doing it manually, the Master Forge must be updated one :ref:`digitizer<Master Forge:The Digitizers>` at a time.
 
-       		   .. _Connect Button Emergency:
-     		   .. image:: /assets/images/FW-connect-button.jpg
-    		      :width: 600
-    		      :alt: Connect Button on Device Manager
- 		#. When the popup box comes up that reads “manager.charachorder.com wants to connect to a serial port”, choose the CCOS device you wish to update, then click the blue “connect” button
+    #. On a chromium based browser, such as Chrome, go to the CharaChorder `Device Manager <https://charachorder.io/ccos/>`__
+    #. If not auto-connected, click "Connect"
 
-        		 .. _Serial Port Popup Emergency:
-      		  .. image:: /assets/images/SerialPort-Message-M4G.webp
-       		   :width: 435
-        		  :alt: Popup to select serial device
- 		#. If not already on the Firmware Updates page, click "CCOS Updates" at the bottom left of the page
+    .. _Connect Button Emergency:
+    .. image:: /assets/images/FW-connect-button.jpg
+        :width: 600
+        :alt: Connect Button on Device Manager
 
-        		 .. _Firmware Updates Page:
-     		   .. image:: /assets/images/DM-CCOS-button.jpg
-     		     :width: 600
-      		    :alt: CCOS button
- 		#. You can compare the latest release (the version at the top of the list) with your device's version. Select your desired version.
- 		#. Use the blue "Bootloader" text to reboot your device into bootloader
+    #. When the popup box comes up that reads “manager.charachorder.com wants to connect to a serial port”, choose the CCOS device you wish to update, then click the blue “connect” button
 
-       		  .. _Bootloader button:
-      		  .. image:: /assets/images/DM-Bootloader-button.jpg
-        		  :width: 600
-        		  :alt: Bootloader button
- 		#. Click the blue "CURRENT.UF2" text to download the firmware file
+    .. _Serial Port Popup Emergency:
+    .. image:: /assets/images/SerialPort-Message-M4G.webp
+        :width: 435
+        :alt: Popup to select serial device
 
-      		   .. _Current.uf2 button:
-      		  .. image:: /assets/images/DM-UF2-button.jpg
-       		   :width: 600
-        		  :alt: CURRENT.UF2 button
+    #. If not already on the Firmware Updates page, click "CCOS Updates" at the bottom left of the page
 
-			.. warning::
-   				IMPORTANT: Make sure that the file you download is named exactly like this: CURRENT.UF2 . If there are any other characters in the file name, the file will not work. “CURRENT.UF2(1)” will NOT work. Additionally, the file name is case sensitive; all letters must be capitalized.
+    .. _Firmware Updates Page:
+    .. image:: /assets/images/DM-CCOS-button.jpg
+        :width: 600
+        :alt: CCOS button
 
+    #. You can compare the latest release (the version at the top of the list) with your device's version. Select your desired version.
+    #. Use the blue "Bootloader" text to reboot your device into bootloader
 
+    .. _Bootloader button:
+    .. image:: /assets/images/DM-Bootloader-button.jpg
+        :width: 600
+        :alt: Bootloader button
 
- 		#. Copy the CURRENT.UF2 file that you just downloaded and paste it into the Forge drive in your file explorer
- 		#. When your computer asks you how you would like to resolve the issue of two files with the same name, select “Replace file”.
+    #. Click the blue "CURRENT.UF2" text to download the firmware file
 
-			At this point, your Forge will automatically reboot and the Forge drive will have disappeared. Congratulations! You have successfully updated your device. You can check your device’s firmware version by following the steps :ref:`here<m4g-checking-your-devices-firmware>`.
+    .. _Current.uf2 button:
+    .. image:: /assets/images/DM-UF2-button.jpg
+        :width: 600
+        :alt: CURRENT.UF2 button
 
- 		#. Now, back in the `Firmware Updates page <https://charachorder.io/ccos/>`__, select ``m4gr_s3``
- 		#. If you haven't done so already, Connect your device to the Manager again by clicking "Connect" at the bottom of the page
+    .. warning::
 
-      		   .. _Connect Button:
-     		   .. image:: /assets/images/FW-connect-button.jpg
-     		     :width: 600
-     		     :alt: Connect Button on Device Manager
- 		#. When the popup box comes up that reads “charachorder.io wants to connect to a serial port”, choose your Master Forge, then click the blue “connect” button
+        IMPORTANT: Make sure that the file you download is named exactly like this: CURRENT.UF2 . If there are any other characters in the file name, the file will not work. “CURRENT.UF2(1)” will NOT work. Additionally, the file name is case sensitive; all letters must be capitalized.
 
-        		 .. _Serial Port Popup:
-       		 .. image:: /assets/images/SerialPort-Message-M4G.webp
-       		   :width: 435
-      		    :alt: Popup to select serial device
- 		#. Use the blue "Bootloader" text to reboot the right digitizer into bootloader
+        #. Copy the CURRENT.UF2 file that you just downloaded and paste it into the Forge drive in your file explorer
+        #. When your computer asks you how you would like to resolve the issue of two files with the same name, select “Replace file”.
 
-     		    .. _Bootloader button:
-    		    .. image:: /assets/images/DM-Bootloader-button.jpg
-     		     :width: 600
-    		      :alt: Bootloader button
- 		#. Click the blue "CURRENT.UF2" text to download the firmware file
+        At this point, your Forge will automatically reboot and the Forge drive will have disappeared. Congratulations! You have successfully updated your device. You can check your device’s firmware version by following the steps :ref:`here<m4g-checking-your-devices-firmware>`.
 
-      		   .. _Current.uf2 button:
-       		 .. image:: /assets/images/DM-UF2-button.jpg
-        		  :width: 600
-        		  :alt: CURRENT.UF2 button
+        #. Now, back in the `Firmware Updates page <https://charachorder.io/ccos/>`__, select ``m4gr_s3``
+        #. If you haven't done so already, Connect your device to the Manager again by clicking "Connect" at the bottom of the page
 
-			.. warning::
-   				IMPORTANT: Make sure that the file you download is named exactly like this: CURRENT.UF2 . If there are any other characters in the file name, the file will not work. “CURRENT.UF2(1)” will NOT work. Additionally, the file name is case sensitive; all letters must be capitalized.
+        .. _Connect Button:
+        .. image:: /assets/images/FW-connect-button.jpg
+            :width: 600
+            :alt: Connect Button on Device Manager
 
-		 #. Copy the CURRENT.UF2 file that you just downloaded and paste it into the Forge drive in your file explorer
-		 #. When your computer asks you how you would like to resolve the issue of two files with the same name, select “Replace file”.
+        #. When the popup box comes up that reads “charachorder.io wants to connect to a serial port”, choose your Master Forge, then click the blue “connect” button
 
-		Once again, your Forge will automatically reboot and the
+        .. _Serial Port Popup:
+        .. image:: /assets/images/SerialPort-Message-M4G.webp
+            :width: 435
+            :alt: Popup to select serial device
 
-  Forge drive will have disappeared. You can check your device’s firmware
-  version by following the steps :ref:`here<m4g-checking-your-devices-firmware>`.
+        #. Use the blue "Bootloader" text to reboot the right digitizer into bootloader
+
+        .. _Bootloader button:
+        .. image:: /assets/images/DM-Bootloader-button.jpg
+            :width: 600
+            :alt: Bootloader button
+
+        #. Click the blue "CURRENT.UF2" text to download the firmware file
+
+        .. _Current.uf2 button:
+        .. image:: /assets/images/DM-UF2-button.jpg
+            :width: 600
+            :alt: CURRENT.UF2 button
+
+        .. warning::
+
+            IMPORTANT: Make sure that the file you download is named exactly like this: CURRENT.UF2 . If there are any other characters in the file name, the file will not work. “CURRENT.UF2(1)” will NOT work. Additionally, the file name is case sensitive; all letters must be capitalized.
+
+        #. Copy the CURRENT.UF2 file that you just downloaded and paste it into the Forge drive in your file explorer
+        #. When your computer asks you how you would like to resolve the issue of two files with the same name, select “Replace file”.
+
+    Once again, your Forge will automatically reboot and the
+
+    Forge drive will have disappeared. You can check your device’s firmware
+    version by following the steps :ref:`here<m4g-checking-your-devices-firmware>`.
 
 
 Understanding the Settings
@@ -455,20 +465,20 @@ Learning the Layout
 The default Master Forge layout, which we will refer to as the M4 English layout, has been designed to favor bigrams and trigrams commonly used in the English language while making the letters accessible for a logical choice of :doc:`lexical chords<Chords>`. You can find the quick reference guide for the layout below, and :ref:`read about how the layout was designed, here <Layout:Design of the layout>`.
 
 .. note::
-   General consensus amongst the community is that, while not perfect,
-   the letter arrangement of the default layout is good enough that further modifications would provide very little benefit
-   considering 500+ WPM have been reached in peak conditions.
+    General consensus amongst the community is that, while not perfect,
+    the letter arrangement of the default layout is good enough that further modifications would provide very little benefit
+    considering 500+ WPM have been reached in peak conditions.
 
-   **Most commonly only special character and number placement are changed**, for example to benefit coding.
+    **Most commonly only special character and number placement are changed**, for example to benefit coding.
 
-   Some exceptions include optimizing for VIM bindings, though people have successfully used the default layout for VIM as well
-   and benefits of such modifications are debatable.
+    Some exceptions include optimizing for VIM bindings, though people have successfully used the default layout for VIM as well
+    and benefits of such modifications are debatable.
 
 
 .. _M4English Layout:
 .. image:: /assets/images/M4-Layout.png
-  :width: 1200
-  :alt: M4 English Layout
+    :width: 1200
+    :alt: M4 English Layout
 
 Layers
 ~~~~~~
@@ -505,8 +515,8 @@ A1 Layer
 
 .. _M4G Alpha Layer:
 .. image:: /assets/images/AlphaL.JPG
-  :width: 1200
-  :alt: The Alpha Layer
+    :width: 1200
+    :alt: The Alpha Layer
 
 The A1 layer is the main layer that is active by default. The M4 English
 layout has all 26 letters of the English alphabet on the A1 layer so
@@ -525,8 +535,8 @@ A2 Layer
 
 .. _M4G Num Layer:
 .. image:: /assets/images/NumberL.JPG
-  :width: 1200
-  :alt: The Numeric Layer
+    :width: 1200
+    :alt: The Numeric Layer
 
 The A2 layer, sometimes referred to as the “number layer”, is accessible
 with the :doc:`A2 access key<CharaChorder Keys>`. In the above :ref:`graphic<CCEnglish Layout>`, you’ll see this labeled
@@ -542,9 +552,9 @@ need to :doc:`chord<Chords>` the keys together; it’s only required that the
 A2 Layer access key is pressed while the target key is pressed.
 
 .. note::
-   EXAMPLE: On the M4 English layout, you can access the number
-   ``4`` by pressing and holding the right pinky to the east and the
-   left middle finger to the east.
+    EXAMPLE: On the M4 English layout, you can access the number
+    ``4`` by pressing and holding the right pinky to the east and the
+    left middle finger to the east.
 
 
 A3 Layer
@@ -552,8 +562,8 @@ A3 Layer
 
 .. _M4G Function Layer:
 .. image:: /assets/images/FunctionL.JPG
-  :width: 1200
-  :alt: The Function Layer
+    :width: 1200
+    :alt: The Function Layer
 
 The A3 layer, sometimes referred to as the “function layer”, is
 accessible with the :doc:`A3 access key<CharaChorder Keys>`. This key is not
@@ -564,8 +574,8 @@ this key has the name “Function Layer (Left)” and “Function Layer (Right)�
 By default, the A3 Layer is accessible by [INFO]. You do not have to hold them both in order to access the A3 layer. Any key that is on the A3 Layer can only be accessed by pressing and holding the :doc:`A3 access key<CharaChorder Keys>`, along with the target key. You do not need to :doc:`chord<Chords>` the keys together; it’s only required that the A3 layer access key is pressed while the target key is pressed.
 
 .. note::
-   EXAMPLE: On the M4 English layout, you can access the F1 key by
-   pressing and holding [INFO] and adding the letter ``a`` or ``r`` (location of number 1 on the default layout) to it.
+    EXAMPLE: On the M4 English layout, you can access the F1 key by
+    pressing and holding [INFO] and adding the letter ``a`` or ``r`` (location of number 1 on the default layout) to it.
 
 
 Shift Modifier
@@ -573,33 +583,33 @@ Shift Modifier
 
 .. dropdown:: List of shifted key actions
 
-        .. csv-table:: Shifted Key Actions
-           :header-rows: 1
-           :stub-columns: 0
-           :widths: auto
+    .. csv-table:: Shifted Key Actions
+        :header-rows: 1
+        :stub-columns: 0
+        :widths: auto
 
-           "Alpha key", "Shifted key"
-           "\`", "~"
-           "1", "\!"
-           "2", "\@"
-           "3", "\#"
-           "4", "\$"
-           "5", "\%"
-           "6", "\^"
-           "7", "\&"
-           "8", "\*"
-           "9", "\("
-           "0", "\)"
-           "\-", "\_"
-           "=", "\+"
-           "[", "\{"
-           "]", "\}"
-           "\\", "\|"
-           ";", ":"
-           "\'", """"
-           "\,", "\<"
-           ".", ">"
-           "/", "?"
+        "Alpha key", "Shifted key"
+        "\`", "~"
+        "1", "\!"
+        "2", "\@"
+        "3", "\#"
+        "4", "\$"
+        "5", "\%"
+        "6", "\^"
+        "7", "\&"
+        "8", "\*"
+        "9", "\("
+        "0", "\)"
+        "\-", "\_"
+        "=", "\+"
+        "[", "\{"
+        "]", "\}"
+        "\\", "\|"
+        ";", ":"
+        "\'", """"
+        "\,", "\<"
+        ".", ">"
+        "/", "?"
 
 
 
@@ -623,12 +633,12 @@ holding the Shift key along with the target key. You do not need to
 key is pressed while the target key is pressed.
 
 .. note::
-   EXAMPLE: On the M4 English layout, you can access the capital
-   ``A`` by pressing and holding the left pinky to the east and the
-   right index finger to the west.
+    EXAMPLE: On the M4 English layout, you can access the capital
+    ``A`` by pressing and holding the left pinky to the east and the
+    right index finger to the west.
 
-   On the M4 English layout, you can access the ``@`` symbol by pressing
-   and holding both pinkies to the east and the left index south.
+    On the M4 English layout, you can access the ``@`` symbol by pressing
+    and holding both pinkies to the east and the left index south.
 
 Configurability
 ~~~~~~~~~~~~~~~
@@ -644,26 +654,25 @@ works and how to remap your device, visit the :ref:`remapping section<Device Man
 Master Forge Configurations
 ***************************
 
-When the Master Forge was `unveiled <https://youtu.be/fux9gU3M25E?si=u4KW7OaUUUNINfKD&t=1025>`__ in November of 2023, CharaChorder began taking pre-orders offering everyone the same bundle. In September of 2024, CharaChorder ran a `Kickstarter <https://www.kickstarter.com/projects/charachorder/the-master-forge-a-keyboard-built-for-you>`__ campaign for the Master Forge for 5 weeks, offering three different tiers, each with a different configuration. After the Kickstarter campaign finished, the Master Forge went on back-order sale on the `Forge website <https://forgekeyboard.com>`__. The following section identifies what each of these 5 bundles included. 
+When the Master Forge was `unveiled <https://youtu.be/fux9gU3M25E?si=u4KW7OaUUUNINfKD&t=1025>`__ in November of 2023, CharaChorder began taking pre-orders offering everyone the same bundle. In September of 2024, CharaChorder ran a `Kickstarter <https://www.kickstarter.com/projects/charachorder/the-master-forge-a-keyboard-built-for-you>`__ campaign for the Master Forge for 5 weeks, offering three different tiers, each with a different configuration. After the Kickstarter campaign finished, the Master Forge went on back-order sale on the `Forge website <https://forgekeyboard.com>`__. The following section identifies what each of these 5 bundles included.
 
 Forge Website Pre-Orders
 ------------------------
 The Master Forge was announced at CharaChorder's annual `ChorderCon in 2023 <https://youtu.be/fux9gU3M25E?si=WmNs4bxXJcg0JbKM>`__. It was announced alongside the Forge brand and other Forge products such as the Coder's Forge and the Gamer's Forge. After a surge in Master Forge orders, the Master Forge was given development priority. Every Master Forge order placed between November 2023 and early August 2024 includes:
 
-    - :ref:`One (1) Left Digitizer<Master Forge:The Digitizers>`
-    - :ref:`One (1) Right Digitizer<Master Forge:The Digitizers>`
-    - :ref:`One (1) Electrical Bridge Connector<Master Forge:The Bridge Connector>`
-    - :ref:`One (1) Mechanical Bridge Bolt-On<Master Forge:The Bridge Connector>`
-    - :ref:`One (1) USB-A to USB-C Power Cable<Master Forge:Connections>`
-    - :ref:`One (1) Ergo Bolt-On set<Bolt-Ons:Ergo>`
-    - :ref:`Two (2) Forge Trackball Bolt-Ons<Bolt-Ons:Trackball>`
-    - :ref:`One (1) Tactical Carrying Case<Case>`
-    - :ref:`One (1) Forge Cleat<Add-Ons:Cleat>`
-    - One (1) M3 Allen wrench
-    - :ref:`One (1) Original Backer Deskmat<Add-Ons:Original Backer Deskmat>`
+- :ref:`One (1) Left Digitizer<Master Forge:The Digitizers>`
+- :ref:`One (1) Right Digitizer<Master Forge:The Digitizers>`
+- :ref:`One (1) Electrical Bridge Connector<Master Forge:The Bridge Connector>`
+- :ref:`One (1) Mechanical Bridge Bolt-On<Master Forge:The Bridge Connector>`
+- :ref:`One (1) USB-A to USB-C Power Cable<Master Forge:Connections>`
+- :ref:`One (1) Ergo Bolt-On set<Bolt-Ons:Ergo>`
+- :ref:`Two (2) Forge Trackball Bolt-Ons<Bolt-Ons:Trackball>`
+- :ref:`One (1) Tactical Carrying Case<Case>`
+- :ref:`One (1) Forge Cleat<Add-Ons:Cleat>`
+- One (1) M3 Allen wrench
+- :ref:`One (1) Original Backer Deskmat<Add-Ons:Original Backer Deskmat>`
 
 .. note::
-
     As of March of 2025, the Forge Trackball Bolt-On has not finished development. As such, some pre-orders and Kickstarter backers may not receive their trackball bolt-ons with their Master Forge. These will be shipped at a later time.
 
 
@@ -676,54 +685,54 @@ Basic
 ~~~~~
 The Basic backer tier on Kickstarter includes the following:
 
-    - :ref:`One (1) Left Digitizer<Master Forge:The Digitizers>`
-    - :ref:`One (1) Right Digitizer<Master Forge:The Digitizers>`
-    - :ref:`One (1) Electrical Bridge Connector<Master Forge:The Bridge Connector>`
-    - :ref:`One (1) Mechanical Bridge Bolt-On<Master Forge:The Bridge Connector>`
-    - :ref:`One (1) USB-A to USB-C Power Cable<Master Forge:Connections>`
-    - :ref:`One (1) "Original Backer" Tactical Carrying Case<Case>`
-    - One (1) M3 Allen Wrench
-    - Unlimited Forge CAD Access
+- :ref:`One (1) Left Digitizer<Master Forge:The Digitizers>`
+- :ref:`One (1) Right Digitizer<Master Forge:The Digitizers>`
+- :ref:`One (1) Electrical Bridge Connector<Master Forge:The Bridge Connector>`
+- :ref:`One (1) Mechanical Bridge Bolt-On<Master Forge:The Bridge Connector>`
+- :ref:`One (1) USB-A to USB-C Power Cable<Master Forge:Connections>`
+- :ref:`One (1) "Original Backer" Tactical Carrying Case<Case>`
+- One (1) M3 Allen Wrench
+- Unlimited Forge CAD Access
 
 Premium
 ~~~~~~~
 The Premium backer tier on Kickstarter includes the following:
 
-    - :ref:`One (1) Left Digitizer<Master Forge:The Digitizers>`
-    - :ref:`One (1) Right Digitizer<Master Forge:The Digitizers>`
-    - :ref:`One (1) Electrical Bridge Connector<Master Forge:The Bridge Connector>`
-    - :ref:`One (1) Mechanical Bridge Bolt-On<Master Forge:The Bridge Connector>`
-    - :ref:`One (1) USB-A to USB-C Power Cable<Master Forge:Connections>`
-    - :ref:`One (1) USB-C to USB-C Cable<Master Forge:Connections>`
-    - :ref:`One (1) Forge Trackball Bolt-On<Bolt-Ons:Trackball>`
-    - :ref:`One (1) "Original Backer" Tactical Carrying Case<Case>`
-    - :ref:`One (1) "Original Backer" Deskmat<Add-Ons:Original Backer Deskmat>`
-    - One (1) M3 Allen Wrench
-    - :ref:`One (1) Forge Cleat<Add-Ons:Cleat>`
-    - :ref:`Four (4) Ergo Bolt-On sets<Bolt-Ons:Ergo>`
-    - Unlimited Forge CAD Access
-    - 2 Years of VIP Membership
+- :ref:`One (1) Left Digitizer<Master Forge:The Digitizers>`
+- :ref:`One (1) Right Digitizer<Master Forge:The Digitizers>`
+- :ref:`One (1) Electrical Bridge Connector<Master Forge:The Bridge Connector>`
+- :ref:`One (1) Mechanical Bridge Bolt-On<Master Forge:The Bridge Connector>`
+- :ref:`One (1) USB-A to USB-C Power Cable<Master Forge:Connections>`
+- :ref:`One (1) USB-C to USB-C Cable<Master Forge:Connections>`
+- :ref:`One (1) Forge Trackball Bolt-On<Bolt-Ons:Trackball>`
+- :ref:`One (1) "Original Backer" Tactical Carrying Case<Case>`
+- :ref:`One (1) "Original Backer" Deskmat<Add-Ons:Original Backer Deskmat>`
+- One (1) M3 Allen Wrench
+- :ref:`One (1) Forge Cleat<Add-Ons:Cleat>`
+- :ref:`Four (4) Ergo Bolt-On sets<Bolt-Ons:Ergo>`
+- Unlimited Forge CAD Access
+- 2 Years of VIP Membership
 
 
 Super
 ~~~~~
 
-    - :ref:`One (1) Left Digitizer<Master Forge:The Digitizers>`
-    - :ref:`One (1) Right Digitizer<Master Forge:The Digitizers>`
-    - :ref:`One (1) Electrical Bridge Connector<Master Forge:The Bridge Connector>`
-    - :ref:`One (1) Mechanical Bridge Bolt-On<Master Forge:The Bridge Connector>`
-    - :ref:`One (1) USB-A to USB-C Power Cable<Master Forge:Connections>`
-    - :ref:`One (1) USB-C to USB-C Cable<Master Forge:Connections>`
-    - :ref:`One (1) Forge Trackball Bolt-On<Bolt-Ons:Trackball>`
-    - :ref:`One (1) "Original Backer" Tactical Carrying Case<Case>`
-    - :ref:`One (1) "Original Backer" Deskmat<Add-Ons:Original Backer Deskmat>`
-    - One (1) M3 Allen Wrench
-    - :ref:`One (1) Forge Cleat<Add-Ons:Cleat>`
-    - :ref:`Four (4) Ergo Bolt-On sets<Bolt-Ons:Ergo>`
-    - Unlimited Forge CAD Access
-    - Lifetime VIP Membership
-    - GTM Immortalization
-    - Digitizer Exoskeleton signed by Riley Keen, Founder and CEO of CharaChorder
+- :ref:`One (1) Left Digitizer<Master Forge:The Digitizers>`
+- :ref:`One (1) Right Digitizer<Master Forge:The Digitizers>`
+- :ref:`One (1) Electrical Bridge Connector<Master Forge:The Bridge Connector>`
+- :ref:`One (1) Mechanical Bridge Bolt-On<Master Forge:The Bridge Connector>`
+- :ref:`One (1) USB-A to USB-C Power Cable<Master Forge:Connections>`
+- :ref:`One (1) USB-C to USB-C Cable<Master Forge:Connections>`
+- :ref:`One (1) Forge Trackball Bolt-On<Bolt-Ons:Trackball>`
+- :ref:`One (1) "Original Backer" Tactical Carrying Case<Case>`
+- :ref:`One (1) "Original Backer" Deskmat<Add-Ons:Original Backer Deskmat>`
+- One (1) M3 Allen Wrench
+- :ref:`One (1) Forge Cleat<Add-Ons:Cleat>`
+- :ref:`Four (4) Ergo Bolt-On sets<Bolt-Ons:Ergo>`
+- Unlimited Forge CAD Access
+- Lifetime VIP Membership
+- GTM Immortalization
+- Digitizer Exoskeleton signed by Riley Keen, Founder and CEO of CharaChorder
 
 
 Post-Kickstarter
@@ -731,12 +740,10 @@ Post-Kickstarter
 
 Once the Kickstarter campaign ended, the Master Forge was put on sale for pre-orders on the `Forge Website <https://forgekeyboard.com>`__. Orders placed on the Forge website starting October of 2024 include:
 
-    - :ref:`One (1) Left Digitizer<Master Forge:The Digitizers>`
-    - :ref:`One (1) Right Digitizer<Master Forge:The Digitizers>`
-    - :ref:`One (1) Electrical Bridge Connector<Master Forge:The Bridge Connector>`
-    - :ref:`One (1) Mechanical Bridge Bolt-On<Master Forge:The Bridge Connector>`
-    - :ref:`One (1) USB-A to USB-C Power Cable<Master Forge:Connections>`
-    - :ref:`One (1) Tactical Carrying Case<Case>`
-    - One (1) M3 Allen wrench
-
-
+- :ref:`One (1) Left Digitizer<Master Forge:The Digitizers>`
+- :ref:`One (1) Right Digitizer<Master Forge:The Digitizers>`
+- :ref:`One (1) Electrical Bridge Connector<Master Forge:The Bridge Connector>`
+- :ref:`One (1) Mechanical Bridge Bolt-On<Master Forge:The Bridge Connector>`
+- :ref:`One (1) USB-A to USB-C Power Cable<Master Forge:Connections>`
+- :ref:`One (1) Tactical Carrying Case<Case>`
+- One (1) M3 Allen wrench

--- a/docs/SerialAPI.rst
+++ b/docs/SerialAPI.rst
@@ -4,20 +4,20 @@ Serial API
 The Serial API allows users and developers to interact with their CCOS powered device over a serial connection.  This can be used to add and remove chords, change advanced parameters, and perform common commands such as resetting keymaps or resetting the device to factory settings. You can utilize this serial API by using any serial terminal such as `serialterminal.com <https://www.serialterminal.com/>`_ on a `serial enabled web browser <https://caniuse.com/web-serial>`_. The serial connection operates at a baud rate of 115200 bps. In general, a success returns a 0 at the end, while a failure returns a number greater than zero, which represents an error code. When sending Serial API commands to a CharaChorder device, allow for at least 100 microseconds (us) between commands to allow time for the commands to be processed on the device. If there is no time allowed to process commands on the device, then the serial input buffer on the device can fill up and overflow, causing a system crash. Ideally, sequential Serial API commands should be called in a restful manner by waiting for a response from the previous command.
 
 .. figure:: /assets/serial/serialterminal.png
-  :alt: Running some simple commands on serialterminal.com
+    :alt: Running some simple commands on serialterminal.com
 
-  Running some simple commands on serialterminal.com
+    Running some simple commands on serialterminal.com
 
 .. warning::
-   Parameter and keymaps changes, when **committed**, will degrade the flash chip over time (generally a minimum of 10,000 to 25,000 commits are expected to be stable). If you use the commands below, keep in mind that if you accidentally write a program that unnecessarily commits parameters to your device you can wear it out prematurely.  If you plan to programmatically change layouts, for example, you shouldn’t commit the changes unless you need them to persist after power loss.
+    Parameter and keymaps changes, when **committed**, will degrade the flash chip over time (generally a minimum of 10,000 to 25,000 commits are expected to be stable). If you use the commands below, keep in mind that if you accidentally write a program that unnecessarily commits parameters to your device you can wear it out prematurely.  If you plan to programmatically change layouts, for example, you shouldn’t commit the changes unless you need them to persist after power loss.
 
-   Chords are stored on external flash and have a minimum of 100,000 commits before any degradation could be expected; however, we have a custom wear leveling algorithm that targets specific sectors so this should extend much farther and is less of a concern.
+    Chords are stored on external flash and have a minimum of 100,000 commits before any degradation could be expected; however, we have a custom wear leveling algorithm that targets specific sectors so this should extend much farther and is less of a concern.
 
 .. note::
-   Throughout this document, lines prefixed with a ">" symbol represent user input in the examples shown.
+    Throughout this document, lines prefixed with a ">" symbol represent user input in the examples shown.
 
 .. contents::
-   :local:
+    :local:
 
 Commands Overview
 -----------------
@@ -25,16 +25,16 @@ Commands Overview
 Commands are all caps ASCII characters. The return is always one line and includes the command in the return line along with some of the relevant input arguments as well. This makes it more restful and stateless as compared to previous versions of the Serial API.
 
 .. csv-table::
-   :header: "Command", "Description"
+    :header: "Command", "Description"
 
-   ":ref:`CMD<SerialAPI:CMD>`", "Lists available commands."
-   ":ref:`ID<SerialAPI:ID>`", "Identifies device, such as `CHARACHORDER ONE M0`."
-   ":ref:`VERSION<SerialAPI:VERSION>`", "Returns the current firmware version, such as `1.1.1`"
-   ":ref:`CML<SerialAPI:CML>`", "Used for getting, setting (adding or overwriting), and deleting chordmaps."
-   ":ref:`VAR<SerialAPI:VAR>`", "Used for getting and settings parameters; this includes setting custom chordmaps."
-   ":ref:`RST<SerialAPI:RST>`", "Restarts/reboots the microcontroller hardware. It has additional arguments for Factory and Bootloader."
-   ":ref:`RAM<SerialAPI:RAM>`", "Prints the current amount of SRAM available; this is primarily used for debugging."
-   ":ref:`SIM<SerialAPI:SIM>`", "Simulates/injects a chord and outputs the chord output if the chord exists in the chord library; this is primarily used for debugging."
+    ":ref:`CMD<SerialAPI:CMD>`", "Lists available commands."
+    ":ref:`ID<SerialAPI:ID>`", "Identifies device, such as `CHARACHORDER ONE M0`."
+    ":ref:`VERSION<SerialAPI:VERSION>`", "Returns the current firmware version, such as `1.1.1`"
+    ":ref:`CML<SerialAPI:CML>`", "Used for getting, setting (adding or overwriting), and deleting chordmaps."
+    ":ref:`VAR<SerialAPI:VAR>`", "Used for getting and settings parameters; this includes setting custom chordmaps."
+    ":ref:`RST<SerialAPI:RST>`", "Restarts/reboots the microcontroller hardware. It has additional arguments for Factory and Bootloader."
+    ":ref:`RAM<SerialAPI:RAM>`", "Prints the current amount of SRAM available; this is primarily used for debugging."
+    ":ref:`SIM<SerialAPI:SIM>`", "Simulates/injects a chord and outputs the chord output if the chord exists in the chord library; this is primarily used for debugging."
 
 Commands
 --------
@@ -46,18 +46,18 @@ CMD
 The `CMD` command lists out all of the commands in the Serial API. All of the commands are returned in one comma-delimited line. All commands are uppercase ASCII characters.
 
 .. csv-table::
-   :header: "I/O","Index","Name","Type","Example","Notes"
+    :header: "I/O","Index","Name","Type","Example","Notes"
 
-   "INPUT",  "0", "Command", "Chars", "CMD"
-   "OUTPUT", "0", "Command", "Chars", "CMD"
-   "OUTPUT", "1", "Command List", "Chars", "CMD,ID,VERSION,CML,VAR,RST,RAM,SIM","Comma delimited"
+    "INPUT",  "0", "Command", "Chars", "CMD"
+    "OUTPUT", "0", "Command", "Chars", "CMD"
+    "OUTPUT", "1", "Command List", "Chars", "CMD,ID,VERSION,CML,VAR,RST,RAM,SIM","Comma delimited"
 
 Example(s):
 
 .. code-block:: none
 
-   > CMD
-   CMD CMD,ID,VERSION,CML,VAR,RST,RAM,SIM
+    > CMD
+    CMD CMD,ID,VERSION,CML,VAR,RST,RAM,SIM
 
 ID
 ~~
@@ -66,20 +66,20 @@ The `ID` command returns the ASCII name of the device, including the chipset cod
 attached to the computer.
 
 .. csv-table::
-   :header: "I/O","Index","Name","Type","Example","Notes"
+    :header: "I/O","Index","Name","Type","Example","Notes"
 
-   "INPUT","0","Command","Chars","ID",""
-   "OUTPUT","0","Command","Chars","ID",""
-   "OUTPUT","1","Company","Chars","CHARACHORDER",""
-   "OUTPUT","2","Device","Chars","ONE","ONE, LITE, ENGINE, or X"
-   "OUTPUT","3","Chipset","Chars","M0","M0 or S2"
+    "INPUT","0","Command","Chars","ID",""
+    "OUTPUT","0","Command","Chars","ID",""
+    "OUTPUT","1","Company","Chars","CHARACHORDER",""
+    "OUTPUT","2","Device","Chars","ONE","ONE, LITE, ENGINE, or X"
+    "OUTPUT","3","Chipset","Chars","M0","M0 or S2"
 
 Example(s):
 
 .. code-block:: none
 
-   > ID
-   ID CHARACHORDER ONE M0
+    > ID
+    ID CHARACHORDER ONE M0
 
 
 VERSION
@@ -88,18 +88,18 @@ VERSION
 The `VERSION` command returns the current version of the CCOS firmware.
 
 .. csv-table::
-   :header: "I/O","Index","Name","Type","Example","Notes"
+    :header: "I/O","Index","Name","Type","Example","Notes"
 
-   "INPUT","0","Command","Chars","VERSION",""
-   "OUTPUT","0","Command","Chars","VERSION",""
-   "OUTPUT","1","Command List","Chars","1.1.1","Period delimited of MAJOR.MINOR.BUILD"
+    "INPUT","0","Command","Chars","VERSION",""
+    "OUTPUT","0","Command","Chars","VERSION",""
+    "OUTPUT","1","Command List","Chars","1.1.1","Period delimited of MAJOR.MINOR.BUILD"
 
 Example(s):
 
 .. code-block:: none
 
-   > VERSION
-   VERSION 1.1.1
+    > VERSION
+    VERSION 1.1.1
 
 CML
 ~~~
@@ -107,120 +107,120 @@ CML
 The `CML` command provides access to the Chordmap Library.
 
 .. csv-table::
-   :header: "CML SubCommand","Code","Description"
+    :header: "CML SubCommand","Code","Description"
 
-   ":ref:`GET_CHORDMAP_COUNT<SerialAPI:GET_CHORDMAP_COUNT>`","C0","Gets the (decimal) number of chordmaps."
-   ":ref:`GET_CHORDMAP_BY_INDEX<SerialAPI:GET_CHORDMAP_BY_INDEX>`","C1","Gets a chordmap by the index number (hexadecimal uint16) if within range."
-   ":ref:`GET_CHORDMAP_BY_CHORD<SerialAPI:GET_CHORDMAP_BY_CHORD>`","C2","Gets a chordmap by the chord (hexadecimal) value if it is found in the library."
-   ":ref:`SET_CHORDMAP_BY_CHORD<SerialAPI:SET_CHORDMAP_BY_CHORD>`","C3","Sets a chordmap with a chord and output bytes (hexadecimal)."
-   ":ref:`DEL_CHORDMAP_BY_CHORD<SerialAPI:DEL_CHORDMAP_BY_CHORD>`","C4","Deletes a chordmap from the library if the chord exists."
+    ":ref:`GET_CHORDMAP_COUNT<SerialAPI:GET_CHORDMAP_COUNT>`","C0","Gets the (decimal) number of chordmaps."
+    ":ref:`GET_CHORDMAP_BY_INDEX<SerialAPI:GET_CHORDMAP_BY_INDEX>`","C1","Gets a chordmap by the index number (hexadecimal uint16) if within range."
+    ":ref:`GET_CHORDMAP_BY_CHORD<SerialAPI:GET_CHORDMAP_BY_CHORD>`","C2","Gets a chordmap by the chord (hexadecimal) value if it is found in the library."
+    ":ref:`SET_CHORDMAP_BY_CHORD<SerialAPI:SET_CHORDMAP_BY_CHORD>`","C3","Sets a chordmap with a chord and output bytes (hexadecimal)."
+    ":ref:`DEL_CHORDMAP_BY_CHORD<SerialAPI:DEL_CHORDMAP_BY_CHORD>`","C4","Deletes a chordmap from the library if the chord exists."
 
 GET_CHORDMAP_COUNT
 ^^^^^^^^^^^^^^^^^^
 
 .. csv-table::
-   :header: "I/O","Index","Name","Type","Example","Notes"
+    :header: "I/O","Index","Name","Type","Example","Notes"
 
-   "INPUT","0","Command","Chars","CML",""
-   "INPUT","1","SubCommand","Hexadecimal CML Code","C0","Get chordmap count"
-   "OUTPUT","0","Command","Chars","CML",""
-   "OUTPUT","1","SubCommand","Hexadecimal CML Code","C0",""
-   "OUTPUT","2","Data Out","Decimal Number","1347",""
+    "INPUT","0","Command","Chars","CML",""
+    "INPUT","1","SubCommand","Hexadecimal CML Code","C0","Get chordmap count"
+    "OUTPUT","0","Command","Chars","CML",""
+    "OUTPUT","1","SubCommand","Hexadecimal CML Code","C0",""
+    "OUTPUT","2","Data Out","Decimal Number","1347",""
 
 Example(s):
 
 .. code-block:: none
 
-   > CML C0
-   CML C0 1347
+    > CML C0
+    CML C0 1347
 
 GET_CHORDMAP_BY_INDEX
 ^^^^^^^^^^^^^^^^^^^^^
 
 .. csv-table::
-   :header: "I/O","Index","Name","Type","Example","Notes"
+    :header: "I/O","Index","Name","Type","Example","Notes"
 
-   "INPUT","0","Command","Chars","CML",""
-   "INPUT","1","SubCommand","Hexadecimal CML Code","C1","Get chordmap by index"
-   "INPUT","2","Index","Decimal","522",""
-   "OUTPUT","0","Command","Chars","CML",""
-   "OUTPUT","1","SubCommand","Hexadecimal CML Code","C1",""
-   "OUTPUT","2","Index","Decimal","522",""
-   "OUTPUT","3","Chord","Hexadecimal Number","001946418C0000000000000000000000","This will be 0 if index is out of bounds"
-   "OUTPUT","4","Phrase","Hexadecimal CCActionCodes List","6361727065206469656D","`carpe diem`; this will be 0 if index is out of bounds"
-   "OUTPUT","5","Success","Boolean Number","0","This will be 0 on success, or greater than zero for an error if the chordmap did not exist"
+    "INPUT","0","Command","Chars","CML",""
+    "INPUT","1","SubCommand","Hexadecimal CML Code","C1","Get chordmap by index"
+    "INPUT","2","Index","Decimal","522",""
+    "OUTPUT","0","Command","Chars","CML",""
+    "OUTPUT","1","SubCommand","Hexadecimal CML Code","C1",""
+    "OUTPUT","2","Index","Decimal","522",""
+    "OUTPUT","3","Chord","Hexadecimal Number","001946418C0000000000000000000000","This will be 0 if index is out of bounds"
+    "OUTPUT","4","Phrase","Hexadecimal CCActionCodes List","6361727065206469656D","`carpe diem`; this will be 0 if index is out of bounds"
+    "OUTPUT","5","Success","Boolean Number","0","This will be 0 on success, or greater than zero for an error if the chordmap did not exist"
 
 Example(s):
 
 .. code-block:: none
 
-   > CML C1 522
-   CML C1 522 001946418C0000000000000000000000 6361727065206469656D 0
+    > CML C1 522
+    CML C1 522 001946418C0000000000000000000000 6361727065206469656D 0
 
 GET_CHORDMAP_BY_CHORD
 ^^^^^^^^^^^^^^^^^^^^^
 
 .. csv-table::
-   :header: "I/O","Index","Name","Type","Example","Notes"
+    :header: "I/O","Index","Name","Type","Example","Notes"
 
-   "INPUT","0","Command","Chars","CML",""
-   "INPUT","1","SubCommand","Hexadecimal CML Code","C2","get chordmap by chord"
-   "INPUT","2","Chord","Hexadecimal Number","001946418C0000000000000000000000",""
-   "OUTPUT","0","Command","Chars","CML",""
-   "OUTPUT","1","SubCommand","Hexadecimal CML Code","C2",""
-   "OUTPUT","2","Chord","Hexadecimal Number","001946418C0000000000000000000000",""
-   "OUTPUT","3","Phrase","Hexadecimal CCActionCodes List","6361727065206469656D","`carpe diem`; this will be 0 if chordmap is not in the library"
+    "INPUT","0","Command","Chars","CML",""
+    "INPUT","1","SubCommand","Hexadecimal CML Code","C2","get chordmap by chord"
+    "INPUT","2","Chord","Hexadecimal Number","001946418C0000000000000000000000",""
+    "OUTPUT","0","Command","Chars","CML",""
+    "OUTPUT","1","SubCommand","Hexadecimal CML Code","C2",""
+    "OUTPUT","2","Chord","Hexadecimal Number","001946418C0000000000000000000000",""
+    "OUTPUT","3","Phrase","Hexadecimal CCActionCodes List","6361727065206469656D","`carpe diem`; this will be 0 if chordmap is not in the library"
 
 Example(s):
 
 .. code-block:: none
 
-   > CML C2 00000000E4E2B0160F84B20ACE7638C0
-   CML C2 00000000E4E2B0160F84B20ACE7638C0 6361727065206469656D
+    > CML C2 00000000E4E2B0160F84B20ACE7638C0
+    CML C2 00000000E4E2B0160F84B20ACE7638C0 6361727065206469656D
 
 SET_CHORDMAP_BY_CHORD
 ^^^^^^^^^^^^^^^^^^^^^
 
 .. csv-table::
-   :header: "I/O","Index","Name","Type","Example","Notes"
+    :header: "I/O","Index","Name","Type","Example","Notes"
 
-   "INPUT","0","Command","Chars","CML",""
-   "INPUT","1","SubCommand","Hexadecimal CML Code","C3","set chordmap by chord"
-   "INPUT","2","Chord","Hexadecimal Number","001946418C0000000000000000000000",""
-   "INPUT","3","Phrase","Hexadecimal CCActionCodes List","6361727065206469656D","`carpe diem`"
-   "OUTPUT","0","Command","Chars","CML",""
-   "OUTPUT","1","SubCommand","Hexadecimal CML Code","C3",""
-   "OUTPUT","2","Chord","Hexadecimal Number","001946418C0000000000000000000000",""
-   "OUTPUT","3","Phrase","Hexadecimal CCActionCodes List","6361727065206469656D","`carpe diem`; this will be 0 if there was a problem adding this chordmap to the library"
-   "OUTPUT","4","Success","Boolean Number","0","This will be 0 on success, or greater than zero for an error if the chordmap did not exist or the deletion was unsuccessful"
+    "INPUT","0","Command","Chars","CML",""
+    "INPUT","1","SubCommand","Hexadecimal CML Code","C3","set chordmap by chord"
+    "INPUT","2","Chord","Hexadecimal Number","001946418C0000000000000000000000",""
+    "INPUT","3","Phrase","Hexadecimal CCActionCodes List","6361727065206469656D","`carpe diem`"
+    "OUTPUT","0","Command","Chars","CML",""
+    "OUTPUT","1","SubCommand","Hexadecimal CML Code","C3",""
+    "OUTPUT","2","Chord","Hexadecimal Number","001946418C0000000000000000000000",""
+    "OUTPUT","3","Phrase","Hexadecimal CCActionCodes List","6361727065206469656D","`carpe diem`; this will be 0 if there was a problem adding this chordmap to the library"
+    "OUTPUT","4","Success","Boolean Number","0","This will be 0 on success, or greater than zero for an error if the chordmap did not exist or the deletion was unsuccessful"
 
 Example(s):
 
 .. code-block:: none
 
-   > CML C3 00000000E4E2B0160F84B20ACE7638C0 6361727065206469656D
-   CML C3 00000000E4E2B0160F84B20ACE7638C0 6361727065206469656D 0
+    > CML C3 00000000E4E2B0160F84B20ACE7638C0 6361727065206469656D
+    CML C3 00000000E4E2B0160F84B20ACE7638C0 6361727065206469656D 0
 
 DEL_CHORDMAP_BY_CHORD
 ^^^^^^^^^^^^^^^^^^^^^
 
 .. csv-table::
-   :header: "I/O","Index","Name","Type","Example","Notes"
+    :header: "I/O","Index","Name","Type","Example","Notes"
 
-   "INPUT","0","Command","Chars","CML",""
-   "INPUT","1","SubCommand","Hexadecimal CML Code","C4","delete chordmap by chord"
-   "INPUT","2","Chord","Hexadecimal Number","001946418C0000000000000000000000",""
-   "OUTPUT","0","Command","Chars","CML",""
-   "OUTPUT","1","SubCommand","Hexadecimal CML Code","C4",""
-   "OUTPUT","2","Chord","Hexadecimal Number","001946418C0000000000000000000000","This will be 0 if the chordmap did not exist or the deletion was unsuccessful"
-   "OUTPUT","3","Success","Boolean Number","0","This will be 0 on success, or greater than zero for an error if the chordmap did not exist or the deletion was unsuccessful"
+    "INPUT","0","Command","Chars","CML",""
+    "INPUT","1","SubCommand","Hexadecimal CML Code","C4","delete chordmap by chord"
+    "INPUT","2","Chord","Hexadecimal Number","001946418C0000000000000000000000",""
+    "OUTPUT","0","Command","Chars","CML",""
+    "OUTPUT","1","SubCommand","Hexadecimal CML Code","C4",""
+    "OUTPUT","2","Chord","Hexadecimal Number","001946418C0000000000000000000000","This will be 0 if the chordmap did not exist or the deletion was unsuccessful"
+    "OUTPUT","3","Success","Boolean Number","0","This will be 0 on success, or greater than zero for an error if the chordmap did not exist or the deletion was unsuccessful"
 
 Example(s):
 
 .. code-block:: none
 
-   > CML C4 00000000E4E2B0160F84B20ACE7638C0
-   CML C4 00000000E4E2B0160F84B20ACE7638C0 0
+    > CML C4 00000000E4E2B0160F84B20ACE7638C0
+    CML C4 00000000E4E2B0160F84B20ACE7638C0 0
 
 VAR
 ~~~
@@ -231,195 +231,195 @@ VAR Subcommands
 ^^^^^^^^^^^^^^^
 
 .. csv-table::
-   :header: "VAR SubCommand","Code","Description"
+    :header: "VAR SubCommand","Code","Description"
 
-   ":ref:`CMD_VAR_COMMIT<SerialAPI:CMD_VAR_COMMIT>`","B0","Commits any parameter changes to persistent memory."
-   ":ref:`CMD_VAR_GET_PARAMETER<SerialAPI:CMD_VAR_GET_PARAMETER>`","B1","Gets the value of a parameter."
-   ":ref:`CMD_VAR_SET_PARAMETER<SerialAPI:CMD_VAR_SET_PARAMETER>`","B2","Sets the value of a parameter."
-   ":ref:`CMD_VAR_GET_KEYMAP<SerialAPI:CMD_VAR_GET_KEYMAP>`","B3","Gets the value of a key in a keymap."
-   ":ref:`CMD_VAR_SET_KEYMAP<SerialAPI:CMD_VAR_SET_KEYMAP>`","B4","Sets the value of a key in a keymap."
+    ":ref:`CMD_VAR_COMMIT<SerialAPI:CMD_VAR_COMMIT>`","B0","Commits any parameter changes to persistent memory."
+    ":ref:`CMD_VAR_GET_PARAMETER<SerialAPI:CMD_VAR_GET_PARAMETER>`","B1","Gets the value of a parameter."
+    ":ref:`CMD_VAR_SET_PARAMETER<SerialAPI:CMD_VAR_SET_PARAMETER>`","B2","Sets the value of a parameter."
+    ":ref:`CMD_VAR_GET_KEYMAP<SerialAPI:CMD_VAR_GET_KEYMAP>`","B3","Gets the value of a key in a keymap."
+    ":ref:`CMD_VAR_SET_KEYMAP<SerialAPI:CMD_VAR_SET_KEYMAP>`","B4","Sets the value of a key in a keymap."
 
 Keymap codes
 ^^^^^^^^^^^^
 
 .. csv-table::
-   :header: "Keymap Codes","Code","Description"
+    :header: "Keymap Codes","Code","Description"
 
-   "Primary","A1","The default primary keymap. In the CharaChorder One this is called the Alpha keymap, while on the CharaChorder Lite this defaults to a Qwerty layout."
-   "Secondary","A2","The default secondary keymap. In the CharaChorder One this is called the Num-shift keymap, while on the CharaChorder Lite this provides some additional function and numpad keys."
-   "Tertiary","A3","The default tertiary keymap. In the CharaChorder One this is called the Function keymap, while on the CharaChorder Lite this is a copy of the secondary keymap."
+    "Primary","A1","The default primary keymap. In the CharaChorder One this is called the Alpha keymap, while on the CharaChorder Lite this defaults to a Qwerty layout."
+    "Secondary","A2","The default secondary keymap. In the CharaChorder One this is called the Num-shift keymap, while on the CharaChorder Lite this provides some additional function and numpad keys."
+    "Tertiary","A3","The default tertiary keymap. In the CharaChorder One this is called the Function keymap, while on the CharaChorder Lite this is a copy of the secondary keymap."
 
 Parameter codes
 ^^^^^^^^^^^^^^^
 
 .. csv-table::
-   :header: "Parameter Codes","Hexadecimal Code","Description"
+    :header: "Parameter Codes","Hexadecimal Code","Description"
 
-   "Enable Serial Header","0x01","boolean 0 or 1, default is 0"
-   "Enable Serial Logging","0x02","boolean 0 or 1, default is 0"
-   "Enable Serial Debugging","0x03","boolean 0 or 1, default is 0"
-   "Enable Serial Raw","0x04","boolean 0 or 1, default is 0"
-   "Enable Serial Chord","0x05","boolean 0 or 1, default is 0"
-   "Enable Serial Keyboard","0x06","boolean 0 or 1, default is 0"
-   "Enable Serial Mouse","0x07","boolean 0 or 1, default is 0"
-   "Enable USB HID Keyboard","0x11","boolean 0 or 1, default is 1"
-   "Enable Character Entry","0x12","boolean 0 or 1"
-   "GUI-CTRL Swap Mode","0x13","boolean 0 or 1; 1 swaps keymap 0 and 1. (CCL only)"
-   "Key Scan Duration","0x14","scan rate described in milliseconds; default is 2ms = 500Hz"
-   "Key Debounce Press Duration","0x15","debounce time in milliseconds; default is 7ms on the One and 20ms on the Lite"
-   "Key Debounce Release Duration","0x16","debounce time in milliseconds; default is 7ms on the One and 20ms on the Lite"
-   "Keyboard Output Character Microsecond Delays","0x17","delay time in microseconds (one delay for press and again for release); default is 480us; max is 10240us; increments of 40us"
-   "Enable USB HID Mouse","0x21","boolean 0 or 1; default is 1"
-   "Slow Mouse Speed","0x22","pixels to move at the mouse poll rate; default for CC1 is 5 = 250px/s"
-   "Fast Mouse Speed","0x23","pixels to move at the mouse poll rate; default for CC1 is 25 = 1250px/s"
-   "Enable Active Mouse","0x24","boolean 0 or 1; moves mouse back and forth every 60s"
-   "Mouse Scroll Speed","0x25","default is 1; polls at 1/4th the rate of the mouse move updates"
-   "Mouse Poll Duration","0x26","poll rate described in milliseconds; default is 20ms = 50Hz"
-   "Enable Chording","0x31","boolean 0 or 1"
-   "Enable Chording Character Counter Timeout","0x32","boolean 0 or 1; default is 1"
-   "Chording Character Counter Timeout Timer","0x33","0-255 deciseconds; default is 40 or 4.0 seconds"
-   "Chord Detection Press Tolerance(ms)","0x34","1-150 milliseconds"
-   "Chord Detection Release Tolerance(ms)","0x35","1-150 milliseconds"
-   "Enable Spurring","0x41","boolean 0 or 1; default is 1"
-   "Enable Spurring Character Counter Timeout","0x42","boolean 0 or 1; default is 1"
-   "Spurring Character Counter Timeout Timer","0x43","0-255 seconds; default is 240"
-   "Enable Arpeggiates","0x51","boolean 0 or 1; default is 1"
-   "Arpeggiate Tolerance","0x54","in milliseconds; default 800ms"
-   "Compound Tolerance","0x64","in milliseconds; default 1500ms"
-   "LED Brightness","0x81","0-50 (CCL only); default is 5, which draws around 100 mA of current"
-   "LED Color Code","0x82","Color Codes to be listed (CCL only)"
-   "Enable LED Key Highlight (coming soon)","0x83","boolean 0 or 1 (CCL only)"
-   "Enable LEDs","0x84","boolean 0 or 1; default is 1 (CCL only)"
-   "Operating System","0x91",":ref:`Operating system codes<SerialAPI:Operating system codes>` listed below"
-   "Enable Realtime Feedback","0x92","boolean 0 or 1; default is 1"
-   "Enable CharaChorder Ready on startup","0x93","boolean 0 or 1; default is 1"
+    "Enable Serial Header","0x01","boolean 0 or 1, default is 0"
+    "Enable Serial Logging","0x02","boolean 0 or 1, default is 0"
+    "Enable Serial Debugging","0x03","boolean 0 or 1, default is 0"
+    "Enable Serial Raw","0x04","boolean 0 or 1, default is 0"
+    "Enable Serial Chord","0x05","boolean 0 or 1, default is 0"
+    "Enable Serial Keyboard","0x06","boolean 0 or 1, default is 0"
+    "Enable Serial Mouse","0x07","boolean 0 or 1, default is 0"
+    "Enable USB HID Keyboard","0x11","boolean 0 or 1, default is 1"
+    "Enable Character Entry","0x12","boolean 0 or 1"
+    "GUI-CTRL Swap Mode","0x13","boolean 0 or 1; 1 swaps keymap 0 and 1. (CCL only)"
+    "Key Scan Duration","0x14","scan rate described in milliseconds; default is 2ms = 500Hz"
+    "Key Debounce Press Duration","0x15","debounce time in milliseconds; default is 7ms on the One and 20ms on the Lite"
+    "Key Debounce Release Duration","0x16","debounce time in milliseconds; default is 7ms on the One and 20ms on the Lite"
+    "Keyboard Output Character Microsecond Delays","0x17","delay time in microseconds (one delay for press and again for release); default is 480us; max is 10240us; increments of 40us"
+    "Enable USB HID Mouse","0x21","boolean 0 or 1; default is 1"
+    "Slow Mouse Speed","0x22","pixels to move at the mouse poll rate; default for CC1 is 5 = 250px/s"
+    "Fast Mouse Speed","0x23","pixels to move at the mouse poll rate; default for CC1 is 25 = 1250px/s"
+    "Enable Active Mouse","0x24","boolean 0 or 1; moves mouse back and forth every 60s"
+    "Mouse Scroll Speed","0x25","default is 1; polls at 1/4th the rate of the mouse move updates"
+    "Mouse Poll Duration","0x26","poll rate described in milliseconds; default is 20ms = 50Hz"
+    "Enable Chording","0x31","boolean 0 or 1"
+    "Enable Chording Character Counter Timeout","0x32","boolean 0 or 1; default is 1"
+    "Chording Character Counter Timeout Timer","0x33","0-255 deciseconds; default is 40 or 4.0 seconds"
+    "Chord Detection Press Tolerance(ms)","0x34","1-150 milliseconds"
+    "Chord Detection Release Tolerance(ms)","0x35","1-150 milliseconds"
+    "Enable Spurring","0x41","boolean 0 or 1; default is 1"
+    "Enable Spurring Character Counter Timeout","0x42","boolean 0 or 1; default is 1"
+    "Spurring Character Counter Timeout Timer","0x43","0-255 seconds; default is 240"
+    "Enable Arpeggiates","0x51","boolean 0 or 1; default is 1"
+    "Arpeggiate Tolerance","0x54","in milliseconds; default 800ms"
+    "Compound Tolerance","0x64","in milliseconds; default 1500ms"
+    "LED Brightness","0x81","0-50 (CCL only); default is 5, which draws around 100 mA of current"
+    "LED Color Code","0x82","Color Codes to be listed (CCL only)"
+    "Enable LED Key Highlight (coming soon)","0x83","boolean 0 or 1 (CCL only)"
+    "Enable LEDs","0x84","boolean 0 or 1; default is 1 (CCL only)"
+    "Operating System","0x91",":ref:`Operating system codes<SerialAPI:Operating system codes>` listed below"
+    "Enable Realtime Feedback","0x92","boolean 0 or 1; default is 1"
+    "Enable CharaChorder Ready on startup","0x93","boolean 0 or 1; default is 1"
 
 
 Operating system codes
 ^^^^^^^^^^^^^^^^^^^^^^
 
 .. csv-table::
-   :header: "Operating System Codes","Code"
+    :header: "Operating System Codes","Code"
 
-   "Windows","0"
-   "Mac","1"
-   "Linux","2"
-   "iOS","3"
-   "Android","4"
-   "Unknown","255"
+    "Windows","0"
+    "Mac","1"
+    "Linux","2"
+    "iOS","3"
+    "Android","4"
+    "Unknown","255"
 
 CMD_VAR_COMMIT
 ^^^^^^^^^^^^^^
 
 .. csv-table::
-   :header: "I/O","Index","Name","Type","Example","Notes"
+    :header: "I/O","Index","Name","Type","Example","Notes"
 
-   "INPUT","0","Command","Chars","VAR",""
-   "INPUT","1","SubCommand","Hexadecimal VAR Code","B0","Commit parameters to memory"
-   "OUTPUT","0","Command","Chars","VAR",""
-   "OUTPUT","1","SubCommand","Hexadecimal VAR Code","B0",""
-   "OUTPUT","2","Success","Boolean Number","0","This will be 0 on success, or greater than zero for an error if there was a problem commiting"
+    "INPUT","0","Command","Chars","VAR",""
+    "INPUT","1","SubCommand","Hexadecimal VAR Code","B0","Commit parameters to memory"
+    "OUTPUT","0","Command","Chars","VAR",""
+    "OUTPUT","1","SubCommand","Hexadecimal VAR Code","B0",""
+    "OUTPUT","2","Success","Boolean Number","0","This will be 0 on success, or greater than zero for an error if there was a problem commiting"
 
 Example(s):
 
 .. code-block:: none
 
-   > VAR B0
-   VAR B0 1
+    > VAR B0
+    VAR B0 1
 
 CMD_VAR_GET_PARAMETER
 ^^^^^^^^^^^^^^^^^^^^^
 
 .. csv-table::
-   :header: "I/O","Index","Name","Type","Example","Notes"
+    :header: "I/O","Index","Name","Type","Example","Notes"
 
-   "INPUT","0","Command","Chars","VAR",""
-   "INPUT","1","SubCommand","Hexadecimal VAR Code","B1","Get parameter value"
-   "INPUT","2","Parameter Code","Hexadecimal Parameter Code","0x15",""
-   "OUTPUT","0","Command","Chars","VAR",""
-   "OUTPUT","1","SubCommand","Hexadecimal VAR Code","B1",""
-   "OUTPUT","2","Parameter Code","Hexadecimal Parameter Code","0x15",""
-   "OUTPUT","3","Data Out","Decimal Number","7",""
-   "OUTPUT","4","Success","Boolean Number","0","This will be 0 on success, or greater than zero for an error if the VAR Code or Parameter Code doesnt exist"
+    "INPUT","0","Command","Chars","VAR",""
+    "INPUT","1","SubCommand","Hexadecimal VAR Code","B1","Get parameter value"
+    "INPUT","2","Parameter Code","Hexadecimal Parameter Code","0x15",""
+    "OUTPUT","0","Command","Chars","VAR",""
+    "OUTPUT","1","SubCommand","Hexadecimal VAR Code","B1",""
+    "OUTPUT","2","Parameter Code","Hexadecimal Parameter Code","0x15",""
+    "OUTPUT","3","Data Out","Decimal Number","7",""
+    "OUTPUT","4","Success","Boolean Number","0","This will be 0 on success, or greater than zero for an error if the VAR Code or Parameter Code doesnt exist"
 
 Example(s):
 
 .. code-block:: none
 
-   > VAR B1 0x15
-   VAR B1 0x15 7 0
+    > VAR B1 0x15
+    VAR B1 0x15 7 0
 
 CMD_VAR_SET_PARAMETER
 ^^^^^^^^^^^^^^^^^^^^^
 
 .. csv-table::
-   :header: "I/O","Index","Name","Type","Example","Notes"
+    :header: "I/O","Index","Name","Type","Example","Notes"
 
-   "INPUT","0","Command","Chars","VAR",""
-   "INPUT","1","SubCommand","Hexadecimal VAR Code","B2","Set parameter value"
-   "INPUT","2","Parameter Code","Hexadecimal Parameter Code","0x15",""
-   "INPUT","3","Data In","Decimal Number","17",""
-   "OUTPUT","0","Command","Chars","VAR",""
-   "OUTPUT","1","SubCommand","Hexadecimal VAR Code","B2",""
-   "OUTPUT","2","Parameter Code","Hexadecimal Parameter Code","0x15",""
-   "OUTPUT","3","Data Out","Decimal Number","17","This will be a 00 (double zero) if the VAR Code or Parameter Code doesn't exist or the input value is out of range"
-   "OUTPUT","4","Success","Boolean Number","0","This will be 0 on success, or greater than zero for an error if there was a problem"
+    "INPUT","0","Command","Chars","VAR",""
+    "INPUT","1","SubCommand","Hexadecimal VAR Code","B2","Set parameter value"
+    "INPUT","2","Parameter Code","Hexadecimal Parameter Code","0x15",""
+    "INPUT","3","Data In","Decimal Number","17",""
+    "OUTPUT","0","Command","Chars","VAR",""
+    "OUTPUT","1","SubCommand","Hexadecimal VAR Code","B2",""
+    "OUTPUT","2","Parameter Code","Hexadecimal Parameter Code","0x15",""
+    "OUTPUT","3","Data Out","Decimal Number","17","This will be a 00 (double zero) if the VAR Code or Parameter Code doesn't exist or the input value is out of range"
+    "OUTPUT","4","Success","Boolean Number","0","This will be 0 on success, or greater than zero for an error if there was a problem"
 
 Example(s):
 
 .. code-block:: none
 
-   > VAR B2 0x15 17
-   VAR B2 0x15 17 0
+    > VAR B2 0x15 17
+    VAR B2 0x15 17 0
 
 CMD_VAR_GET_KEYMAP
 ^^^^^^^^^^^^^^^^^^
 
 .. csv-table::
-   :header: "I/O","Index","Name","Type","Example","Notes"
+    :header: "I/O","Index","Name","Type","Example","Notes"
 
-   "INPUT","0","Command","Chars","VAR",""
-   "INPUT","1","SubCommand","Hexadecimal VAR Code","B3","Get keymap parameter value"
-   "INPUT","2","Keymap","Hexadecimal Keymap Code","A1",""
-   "INPUT","3","Index","Decimal Number","24","For CC1, 0-89 are valid. For CCL, 0-66 are valid."
-   "OUTPUT","0","Command","Chars","VAR",""
-   "OUTPUT","1","SubCommand","Hexadecimal VAR Code","B3",""
-   "OUTPUT","2","Keymap","Hexadecimal Keymap Code","A1",""
-   "OUTPUT","3","Index","Decimal Number","24",""
-   "OUTPUT","4","Action Id","Decimal Number","111","Valid action Ids range from 8 thru 2047."
-   "OUTPUT","5","Success","Boolean Number","0","This will be 0 on success, or greater than zero for an error if either the Keymap Code or Index are out of range."
+    "INPUT","0","Command","Chars","VAR",""
+    "INPUT","1","SubCommand","Hexadecimal VAR Code","B3","Get keymap parameter value"
+    "INPUT","2","Keymap","Hexadecimal Keymap Code","A1",""
+    "INPUT","3","Index","Decimal Number","24","For CC1, 0-89 are valid. For CCL, 0-66 are valid."
+    "OUTPUT","0","Command","Chars","VAR",""
+    "OUTPUT","1","SubCommand","Hexadecimal VAR Code","B3",""
+    "OUTPUT","2","Keymap","Hexadecimal Keymap Code","A1",""
+    "OUTPUT","3","Index","Decimal Number","24",""
+    "OUTPUT","4","Action Id","Decimal Number","111","Valid action Ids range from 8 thru 2047."
+    "OUTPUT","5","Success","Boolean Number","0","This will be 0 on success, or greater than zero for an error if either the Keymap Code or Index are out of range."
 
 Example(s):
 
 .. code-block:: none
 
-   > VAR B3 A1 24
-   VAR B3 A1 24 111 0
+    > VAR B3 A1 24
+    VAR B3 A1 24 111 0
 
 CMD_VAR_SET_KEYMAP
 ^^^^^^^^^^^^^^^^^^
 
 .. csv-table::
-   :header: "I/O","Index","Name","Type","Example","Notes"
+    :header: "I/O","Index","Name","Type","Example","Notes"
 
-   "INPUT","0","Command","Chars","VAR",""
-   "INPUT","1","SubCommand","Hexadecimal VAR Code","B4","Set keymap parameter value"
-   "INPUT","2","Keymap","Hexadecimal Keymap Code","A1",""
-   "INPUT","3","Index","Decimal Number","24","For CC1, 0-89 are valid. For CCL, 0-66 are"
-   "INPUT","4","Action Id","Decimal Number","112","Valid action Ids range from 8 thru 2047."
-   "OUTPUT","0","Command","Chars","VAR",""
-   "OUTPUT","1","SubCommand","Hexadecimal VAR Code","B4",""
-   "OUTPUT","2","Keymap","Hexadecimal Keymap Code","A0",""
-   "OUTPUT","3","Index","Decimal Number","24",""
-   "OUTPUT","4","Action Id","Decimal Number","112","Valid action Ids range from 8 thru 2047. Returns a 00 if either the Keymap Code or Index or Action Id are out of range."
-   "OUTPUT","5","Success","Boolean Number","0","This will be 0 on success, or greater than zero for an error if the chordmap did not exist or the deletion was unsuccessful"
+    "INPUT","0","Command","Chars","VAR",""
+    "INPUT","1","SubCommand","Hexadecimal VAR Code","B4","Set keymap parameter value"
+    "INPUT","2","Keymap","Hexadecimal Keymap Code","A1",""
+    "INPUT","3","Index","Decimal Number","24","For CC1, 0-89 are valid. For CCL, 0-66 are"
+    "INPUT","4","Action Id","Decimal Number","112","Valid action Ids range from 8 thru 2047."
+    "OUTPUT","0","Command","Chars","VAR",""
+    "OUTPUT","1","SubCommand","Hexadecimal VAR Code","B4",""
+    "OUTPUT","2","Keymap","Hexadecimal Keymap Code","A0",""
+    "OUTPUT","3","Index","Decimal Number","24",""
+    "OUTPUT","4","Action Id","Decimal Number","112","Valid action Ids range from 8 thru 2047. Returns a 00 if either the Keymap Code or Index or Action Id are out of range."
+    "OUTPUT","5","Success","Boolean Number","0","This will be 0 on success, or greater than zero for an error if the chordmap did not exist or the deletion was unsuccessful"
 
 Example(s):
 
 .. code-block:: none
 
-   > VAR B4 A0 24 112
-   VAR B4 A0 24 112 0
+    > VAR B4 A0 24 112
+    VAR B4 A0 24 112 0
 
 RST
 ~~~
@@ -427,28 +427,28 @@ RST
 The `RST` command restarts the CCOS device. This will most likely also break the current Serial connection, and a new connection will need to be made. If the `COMMIT` command has not been called before a `RESTART` command, then the device will revert to the last settings stored in the non-volatile memory.
 
 .. csv-table::
-   :header: "I/O","Index","Name","Type","Example","Notes"
+    :header: "I/O","Index","Name","Type","Example","Notes"
 
-   "INPUT","0","Command","Chars","RST",""
-   "OUTPUT","0","Command","Chars","RST","Without optional command, this just restarts the device"
-   "OUTPUT","1","SubCommand","Chars","BOOTLOADER","See full list of subcommands below"
-   "OUTPUT","2","Success","Boolean Number","0","This will be 0 on success, or greater than zero for an error if the subcommand did not exist or the subcommand was unsuccessful"
+    "INPUT","0","Command","Chars","RST",""
+    "OUTPUT","0","Command","Chars","RST","Without optional command, this just restarts the device"
+    "OUTPUT","1","SubCommand","Chars","BOOTLOADER","See full list of subcommands below"
+    "OUTPUT","2","Success","Boolean Number","0","This will be 0 on success, or greater than zero for an error if the subcommand did not exist or the subcommand was unsuccessful"
 
 RST SubCommands
 ^^^^^^^^^^^^^^^
 
 .. csv-table::
-   :header: "RST SubCommand","Notes"
+    :header: "RST SubCommand","Notes"
 
-   "RESTART","Restarts the microcontroller."
-   "FACTORY","Performs a factory reset of the flash and emulated eeprom. During the process, the flash chip is erased."
-   "BOOTLOADER","Restarts the device into a bootloader mode. On a CC1 or CCL M0, the device may be stuck in UF2 bootloader mode until a UF2 file is pasted into the mass storage device. You can copy and paste the UF2 file already in the mass storage device."
-   "PARAMS","Resets the parameters to factory defaults and commits."
-   "KEYMAPS","Resets the keymaps to the factory defaults and commits."
-   "STARTER","Adds starter chordmaps. This does not clear the chordmap library, but adds to it, replacing those that have the same chord."
-   "CLEARCML","Permanently deletes all the chordmaps stored in the device memory."
-   "UPGRADECML","Attempts to upgrade chordmaps that the system detects are older. This is under development."
-   "FUNC","Adds back in functional chords such as CAPSLOCKS and Backspace-X chords."
+    "RESTART","Restarts the microcontroller."
+    "FACTORY","Performs a factory reset of the flash and emulated eeprom. During the process, the flash chip is erased."
+    "BOOTLOADER","Restarts the device into a bootloader mode. On a CC1 or CCL M0, the device may be stuck in UF2 bootloader mode until a UF2 file is pasted into the mass storage device. You can copy and paste the UF2 file already in the mass storage device."
+    "PARAMS","Resets the parameters to factory defaults and commits."
+    "KEYMAPS","Resets the keymaps to the factory defaults and commits."
+    "STARTER","Adds starter chordmaps. This does not clear the chordmap library, but adds to it, replacing those that have the same chord."
+    "CLEARCML","Permanently deletes all the chordmaps stored in the device memory."
+    "UPGRADECML","Attempts to upgrade chordmaps that the system detects are older. This is under development."
+    "FUNC","Adds back in functional chords such as CAPSLOCKS and Backspace-X chords."
 
 
 RAM
@@ -457,19 +457,19 @@ RAM
 The `RAM` command returns the current number of bytes availabe in SRAM. This is useful for debugging when there is a suspected heap or stack issue.
 
 .. csv-table::
-   :header: "I/O","Index","Name","Type","Example","Notes"
+    :header: "I/O","Index","Name","Type","Example","Notes"
 
-   "INPUT","0","Command","Chars","RAM",""
-   "OUTPUT","0","Command","Chars","RAM",""
-   "OUTPUT","1","Bytes Available","Decimal","425",""
+    "INPUT","0","Command","Chars","RAM",""
+    "OUTPUT","0","Command","Chars","RAM",""
+    "OUTPUT","1","Bytes Available","Decimal","425",""
 
 
 Example(s):
 
 .. code-block:: none
 
-   > RAM
-   RAM 425
+    > RAM
+    RAM 425
 
 SIM
 ~~~
@@ -477,28 +477,28 @@ SIM
 The `SIM` command provides a way to inject a chord or key states to be processed by the device. This is primarily used for debugging.
 
 .. csv-table::
-   :header: "I/O","Index","Name","Type","Example","Notes"
+    :header: "I/O","Index","Name","Type","Example","Notes"
 
-   "INPUT","0","Command","Chars","SIM",""
-   "INPUT","1","SubCommand","Chars","CHORD","CHORD or KEYSTATE; may change this to Hexadecimal codes"
-   "INPUT","2","Data In","Hexadecimal Number","001946418C0000000000000000000000","Chords should be 32 characters"
-   "OUTPUT","0","Command","Chars","SIM",""
-   "OUTPUT","1","SubCommand","Chars","CHORD",""
-   "OUTPUT","2","Data In","Hexadecimal Number","001946418C0000000000000000000000",""
-   "OUTPUT","3","Data Out","Hexadecimal CCActionCodes List","6361727065206469656D","`carpe diem`"
+    "INPUT","0","Command","Chars","SIM",""
+    "INPUT","1","SubCommand","Chars","CHORD","CHORD or KEYSTATE; may change this to Hexadecimal codes"
+    "INPUT","2","Data In","Hexadecimal Number","001946418C0000000000000000000000","Chords should be 32 characters"
+    "OUTPUT","0","Command","Chars","SIM",""
+    "OUTPUT","1","SubCommand","Chars","CHORD",""
+    "OUTPUT","2","Data In","Hexadecimal Number","001946418C0000000000000000000000",""
+    "OUTPUT","3","Data Out","Hexadecimal CCActionCodes List","6361727065206469656D","`carpe diem`"
 
 
 Example(s):
 
 .. code-block:: none
 
-   > SIM CHORD 001946418C0000000000000000000000
-   SIM CHORD 001946418C0000000000000000000000 6361727065206469656D
+    > SIM CHORD 001946418C0000000000000000000000
+    SIM CHORD 001946418C0000000000000000000000 6361727065206469656D
 
 .. code-block:: none
 
-   > SIM CHORD 00000000E4E2B0160F84B20ACE7638C0
-   SIM CHORD 00000000E4E2B0160F84B20ACE7638C0 0 # Returns a 0 if there is no chordmap in the library
+    > SIM CHORD 00000000E4E2B0160F84B20ACE7638C0
+    SIM CHORD 00000000E4E2B0160F84B20ACE7638C0 0 # Returns a 0 if there is no chordmap in the library
 
 
 
@@ -510,14 +510,14 @@ There are 128-bits in a chord. The first 8 bits will typically be 0x00, as this 
 The next 120-bit bits are segmented into twelve 10-bit chunks. Each 10-bit value is a 10-bit CC action code. While CC action codes can reference up to 13-bits, only up to 10-bit values can be used for key inputs. The key inputs for a chord are sorted in descending order from greatest in value to least in value.
 
 .. csv-table::
-   :header: "","Chain Index", "Key 1", "Key 2", "Key 3", "Key 4", "Key 5", "Key 6", "Key 7", "Key 8", "Key 9", "Key 10", "Key 11", "Key 12"
-   :widths: 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10
+    :header: "","Chain Index", "Key 1", "Key 2", "Key 3", "Key 4", "Key 5", "Key 6", "Key 7", "Key 8", "Key 9", "Key 10", "Key 11", "Key 12"
+    :widths: 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10
 
-   "bits", "8 bits", "10 bits", "10 bits", "10 bits", "10 bits", "10 bits", "10 bits", "10 bits", "10 bits", "10 bits", "10 bits", "10 bits", "10 bits"
-   "example 1", "0", "w", "r", "o", "l", "d", "", "", "", "", "", "", ""
-   "decimal 1", "0", "119", "114", "111", "108", "100", "0", "0", "0", "0", "0", "0", "0"
-   "example 2", "0", "DUP", "t", "m", "", "", "", "", "", "", "", "", ""
-   "decimal 2", "0", "536", "116", "109", "0", "0", "0", "0", "0", "0", "0", "0", "0"
+    "bits", "8 bits", "10 bits", "10 bits", "10 bits", "10 bits", "10 bits", "10 bits", "10 bits", "10 bits", "10 bits", "10 bits", "10 bits", "10 bits"
+    "example 1", "0", "w", "r", "o", "l", "d", "", "", "", "", "", "", ""
+    "decimal 1", "0", "119", "114", "111", "108", "100", "0", "0", "0", "0", "0", "0", "0"
+    "example 2", "0", "DUP", "t", "m", "", "", "", "", "", "", "", "", ""
+    "decimal 2", "0", "536", "116", "109", "0", "0", "0", "0", "0", "0", "0", "0", "0"
 
 Note that yes it is possible to use the same CC action code multiple times for keys in a chord, but these chords cannot be activated unless the device's keymap has more than one instance of the same CC action code assigned to more than one of the keys on the A1 keymap layer.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,7 @@
 .. this is a comment, it is not rendered
-   when adding new *.rst or *.md files, reference them here
-   in this index.rst for them to be rendered and added to the
-   table of contents
+    when adding new *.rst or *.md files, reference them here
+    in this index.rst for them to be rendered and added to the
+    table of contents
 
 Welcome to the Official CharaChorder Guide!
 ===========================================
@@ -21,20 +21,20 @@ Table of Contents
 =================
 
 .. toctree::
-   :maxdepth: 2
+    :maxdepth: 2
 
-   Master Forge.rst
-   CharaChorder One.rst
-   CharaChorder Two.rst
-   CharaChorder_Lite.rst
-   CharaChorder Engine.rst
-   CharaChorder X.rst
-   CCOS.rst
-   Chords.rst
-   Device Manager.rst
-   FAQs.rst
-   GenerativeTextMenu.rst
-   Glossary.rst
-   Layout.rst
-   SerialAPI.rst
-   Beta Releases.rst
+    Master Forge.rst
+    CharaChorder One.rst
+    CharaChorder Two.rst
+    CharaChorder_Lite.rst
+    CharaChorder Engine.rst
+    CharaChorder X.rst
+    CCOS.rst
+    Chords.rst
+    Device Manager.rst
+    FAQs.rst
+    GenerativeTextMenu.rst
+    Glossary.rst
+    Layout.rst
+    SerialAPI.rst
+    Beta Releases.rst


### PR DESCRIPTION
Unify the indentation to 4 spaces in all .rst files, and readme.md.

Because they used four different indentation sizes:
spaces: 2
spaces: 3
spaces: 4
tab-size: 4

Multiple files used two indentation sizes.
One file used three:

tab-size: 4
```
.. note
	If you have previously selected ...
```

spaces: 2
```
.. image:: /assets/images/ManagerSELECTDEVICE.png
  :width: 400
  :alt: Image showing the dialogue box ...
```

spaces: 3
```
.. ASCII Macros
   ,,,,,,,,,,,,,,
```

---

Why 4 spaces:

- VSCode showed: 4 Default Tab Size
https://code.visualstudio.com/docs/editing/codebasics#_indentation
> By default, VS Code inserts spaces and uses 4 spaces per Tab key.

<img width="216" height="220" alt="image" src="https://github.com/user-attachments/assets/0ca00ba3-9a30-466f-814f-edf3cc6e6ee6" />

- And the Readme in this CharaChorder/docs repository, has a Dropdown example that mentions this indentation size:
https://github.com/CharaChorder/docs#dropdown
```
.. dropdown:: Title of the Dropdown, visible with the DD closed.

    Text inside the dropdown should skip a line then indent once (4 spaces).
```