### PR TITLE
docs(device mgr, GTM) remove deprecated delayed input settings

### DIFF
--- a/docs/Device Manager.rst
+++ b/docs/Device Manager.rst
@@ -314,14 +314,6 @@ In this box, you can change a few settings that relate to using your device for 
 
 	We should adjust this setting if we are having unintentional duplicate characters while typing. Increasing this value will lower the probability that unwanted duplicate characters will appear because it tells :doc:`CCOS<CCOS>` to wait longer before typing an additional character that’s assigned to the same switch-direction. However, having this setting set too high might also cause issues with :doc:`CCOS<CCOS>` not reading intentional double-presses, so it’s recommended to try different numbers in small increments. This setting should be used in connection with the debounce press setting.
 
-.. dropdown:: Output Character Delay
-
-	This setting adds a small delay to keystroke inputs. It is measured in microseconds (μs) and is very small by default.
-
-	You should increase this value if your computer is not accepting all of the characters output by your device, such as when using the :doc:`GTM<GenerativeTextMenu>`. If you are having this issue, your :doc:`GTM<GenerativeTextMenu>` would look weird, with missing chunks or characters.
-
-	If you have a faster computer, then you can lower this setting to make chording and the :doc:`GTM<GenerativeTextMenu>` feel snappier and more responsive.
-
 Mouse
 -----
 .. dropdown:: Mouse???

--- a/docs/GenerativeTextMenu.rst
+++ b/docs/GenerativeTextMenu.rst
@@ -133,29 +133,6 @@ You can find the default debounce release value of the different  CharaChorder d
 | CharaChorder X   | 1 ms           | 0 ms       | 100 ms     | 1 ms          |
 +------------------+----------------+------------+------------+---------------+
 
-Keystroke Delay
-~~~~~~~~~~~~~~~
-
-``Path: GTM > Keyboard > Keystroke Delay``
-
-This setting adds a small delay to keystroke inputs. It is measured in microseconds (μs) and is very small by default.
-
-You should increase this value if your computer is not accepting all of the characters output by your device, such as when using the GTM. If you are having this issue, your GTM would look weird, with missing chunks or characters.
-
-If you have a faster computer, then you can lower this setting to make chording and the GTM feel snappier and more responsive.
-
-This value is adjusted in 40us increments. You can find the default debounce press of the different  CharaChorder devices in the table below:
-
-+------------------+----------------+------------+-------------+--------------+
-| Device           | Default Value  | Min. Value | Max. Value  | Increments   |
-+==================+================+============+=============+==============+
-| CharaChorder One | 480 μs         | 0 μs       | 10200 μs    | 40 μs        |
-+------------------+----------------+------------+-------------+--------------+
-| CharaChorder Lite| 480 μs         | 0 μs       | 10200 μs    | 40 μs        |
-+------------------+----------------+------------+-------------+--------------+
-| CharaChorder X   | 480 μs         | 0 μs       | 10200 μs    | 40 μs        |
-+------------------+----------------+------------+-------------+--------------+
-
 Capslock
 ~~~~~~~~
 


### PR DESCRIPTION
## Purpose of PR
<!-- What this PR does in 1-2 sentences. If it can't fit in 1-2 sentences, the PR may be changing too much (no big deal, try to keep commits and PRs short next time!) -->

Keystroke Delay and Output Character Delay are deprecated
https://discord.com/channels/861730583092658206/1464226571689787676/1464239835010039819

## Changes Made
<!-- Bulleted list of all the changes this PR introduces -->
- remove both related entries
