### PR TITLE
Added a link to the Device Manager documentation

### DIFF
--- a/docs/Chord Modifiers.rst
+++ b/docs/Chord Modifiers.rst
@@ -3,3 +3,4 @@ Chord Modifiers
 ===============
 
 WIP
+See `Device Manager: chord modifiers <https://docs.charachorder.com/Device%20Manager.html#chord-modifiers>`.


### PR DESCRIPTION
This is the first google result for "charachorder chord modifiers": https://docs.charachorder.com/Chord%20Modifiers.html 

I keep ending up at this page even though I KNOW its here... https://docs.charachorder.com/Device%20Manager.html#chord-modifiers